### PR TITLE
Added modifications that let mpas print out PIO error messages

### DIFF
--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -45,7 +45,7 @@ module mpas_io
 #endif
 #endif
 
-   integer, private :: pio_global_ierr
+   integer, private :: pio_global_ierr = PIO_noerr
 
    interface MPAS_io_get_var
       module procedure MPAS_io_get_var_int0d

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -5018,11 +5018,9 @@ module mpas_io
          case (MPAS_IO_ERR_UNINIT_HANDLE)
             call mpas_log_write('MPAS IO Error: Uninitialized I/O handle', MPAS_LOG_ERR)
          case (MPAS_IO_ERR_PIO)
-            !call mpas_log_write('MPAS IO Error: Bad return value from PIO', MPAS_LOG_ERR)
             ierr_local = PIO_strerror(pio_global_ierr, pio_string)
             call mpas_log_write('MPAS IO Error: PIO error $i: '//trim(pio_string), &
                                 messageType=MPAS_LOG_ERR, intArgs=[pio_global_ierr])
-
          case (MPAS_IO_ERR_DATA_MODE)
             call mpas_log_write('MPAS IO Error: Cannot define in data mode', MPAS_LOG_ERR)
          case (MPAS_IO_ERR_NOWRITE)

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -45,6 +45,8 @@ module mpas_io
 #endif
 #endif
 
+   integer, private :: pio_global_ierr
+
    interface MPAS_io_get_var
       module procedure MPAS_io_get_var_int0d
       module procedure MPAS_io_get_var_int1d
@@ -331,6 +333,7 @@ module mpas_io
             pio_ierr = PIO_openfile(ioContext % pio_iosystem, MPAS_io_open % pio_file, pio_iotype, trim(filename), PIO_nowrite)
          endif
          if (pio_ierr /= PIO_noerr) then
+            pio_global_ierr = pio_ierr
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             return
          end if
@@ -342,6 +345,7 @@ module mpas_io
          pio_ierr = PIO_inquire(MPAS_io_open % pio_file, unlimitedDimID=MPAS_io_open % pio_unlimited_dimid)
 !call mpas_log_write('Found unlimited dim $i', intArgs=(/MPAS_io_open % pio_unlimited_dimid/) )
          if (pio_ierr /= PIO_noerr) then
+            pio_global_ierr = pio_ierr
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             return
          end if
@@ -353,6 +357,7 @@ module mpas_io
          if ( MPAS_io_open % pio_unlimited_dimid >= 0 ) then
             pio_ierr = PIO_inq_dimlen(MPAS_io_open % pio_file, MPAS_io_open % pio_unlimited_dimid, MPAS_io_open % preexisting_records)
             if (pio_ierr /= PIO_noerr) then
+               pio_global_ierr = pio_ierr
                if (present(ierr)) ierr = MPAS_IO_ERR_PIO
                return
             end if
@@ -393,6 +398,7 @@ module mpas_io
 
       pio_ierr = PIO_inq_dimname(handle % pio_file, handle % pio_unlimited_dimid, dimname) 
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_NO_UNLIMITED_DIM
          dimname = ' '
          return
@@ -448,6 +454,7 @@ module mpas_io
 
       pio_ierr = PIO_inq_dimid(handle % pio_file, trim(dimname), new_dimlist_node % dimhandle % dimid)
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_MISSING_DIM
          deallocate(new_dimlist_node % dimhandle)
          deallocate(new_dimlist_node)
@@ -459,6 +466,7 @@ module mpas_io
 
       pio_ierr = PIO_inq_dimlen(handle % pio_file, new_dimlist_node % dimhandle % dimid, new_dimlist_node % dimhandle % dimsize)
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          deallocate(new_dimlist_node % dimhandle)
          deallocate(new_dimlist_node)
@@ -576,6 +584,7 @@ module mpas_io
          pio_ierr = PIO_def_dim(handle % pio_file, trim(dimname), dimsize, new_dimlist_node % dimhandle % dimid)
       end if
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          deallocate(new_dimlist_node % dimhandle)
          deallocate(new_dimlist_node)
@@ -660,6 +669,7 @@ module mpas_io
          pio_ierr = PIO_inq_varid(handle % pio_file, trim(fieldname), new_fieldlist_node % fieldhandle % fieldid)
          pio_ierr = PIO_inq_varid(handle % pio_file, trim(fieldname), new_fieldlist_node % fieldhandle % field_desc)
          if (pio_ierr /= PIO_noerr) then
+            pio_global_ierr = pio_ierr
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             deallocate(new_fieldlist_node % fieldhandle)
             deallocate(new_fieldlist_node)
@@ -671,6 +681,7 @@ module mpas_io
          ! Get field type
          pio_ierr = PIO_inq_vartype(handle % pio_file, new_fieldlist_node % fieldhandle % fieldid, new_fieldlist_node % fieldhandle % field_type)
          if (pio_ierr /= PIO_noerr) then
+            pio_global_ierr = pio_ierr
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             deallocate(new_fieldlist_node % fieldhandle)
             deallocate(new_fieldlist_node)
@@ -696,6 +707,7 @@ module mpas_io
          ! Get number of dimensions
          pio_ierr = PIO_inq_varndims(handle % pio_file, new_fieldlist_node % fieldhandle % fieldid, new_fieldlist_node % fieldhandle % ndims)
          if (pio_ierr /= PIO_noerr) then
+            pio_global_ierr = pio_ierr
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             deallocate(new_fieldlist_node % fieldhandle)
             deallocate(new_fieldlist_node)
@@ -709,6 +721,7 @@ module mpas_io
          if (new_fieldlist_node % fieldhandle % ndims > 0) then
             pio_ierr = PIO_inq_vardimid(handle % pio_file, new_fieldlist_node % fieldhandle % fieldid, dimids)
             if (pio_ierr /= PIO_noerr) then
+               pio_global_ierr = pio_ierr
                if (present(ierr)) ierr = MPAS_IO_ERR_PIO
                deallocate(new_fieldlist_node % fieldhandle)
                deallocate(new_fieldlist_node)
@@ -730,6 +743,7 @@ module mpas_io
 
             pio_ierr = PIO_inq_dimlen(handle % pio_file, dimids(i), new_fieldlist_node % fieldhandle % dims(i) % dimsize)
             if (pio_ierr /= PIO_noerr) then
+               pio_global_ierr = pio_ierr
                if (present(ierr)) ierr = MPAS_IO_ERR_PIO
                deallocate(new_fieldlist_node % fieldhandle)
                deallocate(new_fieldlist_node)
@@ -740,6 +754,7 @@ module mpas_io
 
             pio_ierr = PIO_inq_dimname(handle % pio_file, dimids(i), new_fieldlist_node % fieldhandle % dims(i) % dimname)
             if (pio_ierr /= PIO_noerr) then
+               pio_global_ierr = pio_ierr
                if (present(ierr)) ierr = MPAS_IO_ERR_PIO
                deallocate(new_fieldlist_node % fieldhandle)
                deallocate(new_fieldlist_node)
@@ -1013,6 +1028,7 @@ module mpas_io
          pio_ierr = PIO_def_var(handle % pio_file, trim(fieldname), pio_type, dimids, new_fieldlist_node % fieldhandle % field_desc)
       end if
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -1020,6 +1036,7 @@ module mpas_io
       ! Get the varid for use by put_att routines
       pio_ierr = PIO_inq_varid(handle % pio_file, trim(fieldname), new_fieldlist_node % fieldhandle % fieldid)
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -1999,6 +2016,7 @@ module mpas_io
 
 !      call mpas_log_write('Checking for error')
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -2333,6 +2351,7 @@ module mpas_io
          ! pre-existing files.
          if (pio_ierr /= PIO_noerr .and. &
              .not. (handle % external_file_desc .or. handle % preexisting_file)) then
+            pio_global_ierr = pio_ierr
             if (present(ierr)) ierr = MPAS_IO_ERR_PIO
             return
          end if
@@ -2917,6 +2936,7 @@ module mpas_io
          end if
       end if
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3231,6 +3251,7 @@ module mpas_io
       ! Query attribute value
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3241,6 +3262,7 @@ module mpas_io
 
       pio_ierr = PIO_get_att(handle % pio_file, varid, attName, attValue)
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3372,6 +3394,7 @@ module mpas_io
       ! Query attribute value
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3383,6 +3406,7 @@ module mpas_io
 
       pio_ierr = PIO_inq_attlen(handle % pio_file, varid, attName, attlen)
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3390,6 +3414,7 @@ module mpas_io
       allocate(attValue(attlen))
       pio_ierr = PIO_get_att(handle % pio_file, varid, attName, attValue)
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3530,6 +3555,7 @@ module mpas_io
       ! Query attribute value
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3564,6 +3590,7 @@ module mpas_io
 
       end if
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3706,12 +3733,14 @@ module mpas_io
       ! Query attribute value
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
 
       pio_ierr = PIO_inq_attlen(handle % pio_file, varid, attName, attlen)
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3753,6 +3782,7 @@ module mpas_io
 
       end if
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3884,6 +3914,7 @@ module mpas_io
       ! Query attribute value
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -3894,6 +3925,7 @@ module mpas_io
 
       pio_ierr = PIO_get_att(handle % pio_file, varid, attName, attValue)
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -4075,6 +4107,7 @@ module mpas_io
 
       pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -4232,6 +4265,7 @@ module mpas_io
 
       pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -4400,6 +4434,7 @@ module mpas_io
       end if
 
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -4580,6 +4615,7 @@ module mpas_io
          pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
       end if
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
          return
       end if
@@ -4739,6 +4775,7 @@ module mpas_io
 
       pio_ierr = PIO_put_att(handle % pio_file, varid, attName, trim(attValueLocal)) 
       if (pio_ierr /= PIO_noerr) then
+         pio_global_ierr = pio_ierr
 
          if (present(ierr)) ierr = MPAS_IO_ERR_PIO
 
@@ -4751,16 +4788,19 @@ module mpas_io
          if (handle % preexisting_file .and. .not. handle % data_mode) then
             pio_ierr = PIO_redef(handle % pio_file)
             if (pio_ierr /= PIO_noerr) then
+               pio_global_ierr = pio_ierr
                return
             end if
 
             pio_ierr = PIO_put_att(handle % pio_file, varid, attName, trim(attValueLocal)) 
             if (pio_ierr /= PIO_noerr) then
+               pio_global_ierr = pio_ierr
                return
             end if
 
             pio_ierr = PIO_enddef(handle % pio_file)
             if (pio_ierr /= PIO_noerr) then
+               pio_global_ierr = pio_ierr
                return
             end if
 
@@ -4934,6 +4974,7 @@ module mpas_io
          if ( finalize_iosystem ) then
            call PIO_finalize(ioContext % pio_iosystem, pio_ierr)
            if (pio_ierr /= PIO_noerr) then
+              pio_global_ierr = pio_ierr
               if (present(ierr)) ierr = MPAS_IO_ERR_PIO
               return
            end if
@@ -4962,6 +5003,9 @@ module mpas_io
       integer, intent(in) :: ierr
       logical, intent(in) :: fatal
 
+      integer :: ierr_local
+      character(len=StrKIND) :: pio_string
+
       select case (ierr)
          case (MPAS_IO_NOERR)
             ! ... do nothing ...
@@ -4974,7 +5018,11 @@ module mpas_io
          case (MPAS_IO_ERR_UNINIT_HANDLE)
             call mpas_log_write('MPAS IO Error: Uninitialized I/O handle', MPAS_LOG_ERR)
          case (MPAS_IO_ERR_PIO)
-            call mpas_log_write('MPAS IO Error: Bad return value from PIO', MPAS_LOG_ERR)
+            !call mpas_log_write('MPAS IO Error: Bad return value from PIO', MPAS_LOG_ERR)
+            ierr_local = PIO_strerror(pio_global_ierr, pio_string)
+            call mpas_log_write('MPAS IO Error: PIO error $i: '//trim(pio_string), &
+                                messageType=MPAS_LOG_ERR, intArgs=[pio_global_ierr])
+
          case (MPAS_IO_ERR_DATA_MODE)
             call mpas_log_write('MPAS IO Error: Cannot define in data mode', MPAS_LOG_ERR)
          case (MPAS_IO_ERR_NOWRITE)


### PR DESCRIPTION
These changes are similar to those in [MPAS-A PR #1116](https://github.com/MPAS-Dev/MPAS-Model/pull/1116). They allow the framework to save bad return values from PIO routines and query PIO for an appropriate error message when calling the `mpas_log_write` function.