### PR TITLE
Make mpas-framework compatible with cesm2_3_alpha17a EarthWorks version

### DIFF
--- a/src/framework/mpas_attlist.F
+++ b/src/framework/mpas_attlist.F
@@ -30,6 +30,14 @@ module mpas_attlist
       module procedure mpas_add_att_text
    end interface mpas_add_att
 
+   interface mpas_modify_att
+     module procedure mpas_modify_att_int0d
+     module procedure mpas_modify_att_int1d
+     module procedure mpas_modify_att_real0d
+     module procedure mpas_modify_att_real1d
+     module procedure mpas_modify_att_text
+   end interface mpas_modify_att
+
    interface mpas_get_att
       module procedure mpas_get_att_int0d
       module procedure mpas_get_att_int1d
@@ -252,6 +260,216 @@ contains
       write(cursor % attValueText,'(a)') trim(attValue)
 
    end subroutine mpas_add_att_text!}}}
+
+!***********************************************************************
+!
+! routine mpas_modify_att_text
+!
+! > \brief  MPAS modify text attribute routine
+! > \author Matthew Dimond
+! > \date   06/27/23
+! > \details
+! > This routine modifies a text attribute in the attribute list,
+! > and returns a 1 in ierr if the attribute is not found, or the attribute
+! > has a type incompatible with attValue.
+!
+!----------------------------------------------------------------------
+  subroutine mpas_modify_att_text(attList, attName, attValue, ierr)!{{{
+
+    implicit none
+
+    type (att_list_type), pointer :: attList !< Input/Output: Attribute List
+    character (len=*), intent(in) :: attName !< Input: Att. name to modify
+    character (len=*), intent(in) :: attValue !< Input: Updated Att. value
+    integer, intent(out), optional :: ierr !< Output: Error flag
+
+    type (att_list_type), pointer :: cursor
+
+    if (present(ierr)) ierr = 1
+
+    ! Traverse list looking for attName
+    cursor => attlist
+    do while (associated(cursor))
+      if (trim(cursor % attName) == trim(attName)) then
+        if (cursor % attType == MPAS_ATT_TEXT) then
+          if (present(ierr)) ierr = 0
+          write(cursor % attValueText,'(a)') trim(attValue)
+        end if
+        return
+      end if
+      cursor => cursor % next
+    end do
+
+  end subroutine mpas_modify_att_text!}}}
+
+
+!***********************************************************************
+!
+! routine mpas_modify_att_int0d
+!
+! > \brief  MPAS modify 0D integer attribute routine
+! > \author Matthew Dimond
+! > \date   06/27/23
+! > \details
+! > This routine modifies a 0d integer attribute in the attribute list,
+! > and returns a 1 in ierr if the attribute is not found, or the attribute
+! > has a type incompatible with attValue.
+!
+!----------------------------------------------------------------------
+  subroutine mpas_modify_att_int0d(attList, attName, attValue, ierr)!{{{
+
+    implicit none
+
+    type (att_list_type), pointer :: attList !< Input/Output: Attribute List
+    character (len=*), intent(in) :: attName !< Input: Att. name to modify
+    integer, intent(in) :: attValue !< Input: Updated Att. value
+    integer, intent(out), optional :: ierr !< Output: Error flag
+
+    type (att_list_type), pointer :: cursor
+
+    if (present(ierr)) ierr = 1
+
+    ! Traverse list looking for attName
+    cursor => attlist
+    do while (associated(cursor))
+      if (trim(cursor % attName) == trim(attName)) then
+        if (cursor % attType == MPAS_ATT_INT) then
+          if (present(ierr)) ierr = 0
+          cursor % attValueInt = attValue
+        end if
+        return
+      end if
+      cursor => cursor % next
+    end do
+
+  end subroutine mpas_modify_att_int0d!}}}
+
+!***********************************************************************
+!
+! routine mpas_modify_att_int1d
+!
+! > \brief  MPAS modify 1D integer attribute routine
+! > \author Matthew Dimond
+! > \date   06/27/23
+! > \details
+! > This routine modifies a 1d integer attribute in the attribute list,
+! > and returns a 1 in ierr if the attribute is not found, or the attribute
+! > has a type incompatible with attValue.
+!
+!----------------------------------------------------------------------
+  subroutine mpas_modify_att_int1d(attList, attName, attValue, ierr)!{{{
+
+    implicit none
+
+    type (att_list_type), pointer :: attList !< Input/Output: Attribute List
+    character (len=*), intent(in) :: attName !< Input: Att. name to modify
+    integer, dimension(:), intent(in) :: attValue !< Input: Updated Att. value
+    integer, intent(out), optional :: ierr !< Output: Error flag
+
+    type (att_list_type), pointer :: cursor
+
+    if (present(ierr)) ierr = 1
+
+    ! Traverse list looking for attName
+    cursor => attlist
+    do while (associated(cursor))
+      if (trim(cursor % attName) == trim(attName)) then
+        if (cursor % attType == MPAS_ATT_INTA) then
+          if (size(cursor % attValueIntA) == size(attValue)) then
+            if (present(ierr)) ierr = 0
+            cursor % attValueIntA(:) = attValue(:)
+          end if
+        end if
+        return
+      end if
+      cursor => cursor % next
+    end do
+
+  end subroutine mpas_modify_att_int1d!}}}
+
+!***********************************************************************
+!
+! routine mpas_modify_att_real0d
+!
+! > \brief  MPAS modify 0D real attribute routine
+! > \author Matthew Dimond
+! > \date   06/27/23
+! > \details
+! > This routine modifies a 0d real attribute in the attribute list,
+! > and returns a 1 in ierr if the attribute is not found, or the attribute
+! > has a type incompatible with attValue.
+!
+!----------------------------------------------------------------------
+  subroutine mpas_modify_att_real0d(attList, attName, attValue, ierr)!{{{
+
+    implicit none
+
+    type (att_list_type), pointer :: attList !< Input/Output: Attribute List
+    character (len=*), intent(in) :: attName !< Input: Att. name to modify
+    real (kind=RKIND), intent(in) :: attValue !< Input: Updated Att. value
+    integer, intent(out), optional :: ierr !< Output: Error flag
+
+    type (att_list_type), pointer :: cursor
+
+    if (present(ierr)) ierr = 1
+
+    ! Traverse list looking for attName
+    cursor => attlist
+    do while (associated(cursor))
+      if (trim(cursor % attName) == trim(attName)) then
+        if (cursor % attType == MPAS_ATT_REAL) then
+          if (present(ierr)) ierr = 0
+          cursor % attValueReal = attValue
+        end if
+        return
+      end if
+      cursor => cursor % next
+    end do
+
+  end subroutine mpas_modify_att_real0d!}}}
+
+!***********************************************************************
+!
+! routine mpas_modify_att_real1d
+!
+! > \brief  MPAS modify 1D real attribute routine
+! > \author Matthew Dimond
+! > \date   06/27/23
+! > \details
+! > This routine modifies a 1d real attribute in the attribute list,
+! > and returns a 1 in ierr if the attribute is not found, or the attribute
+! > has a type incompatible with attValue.
+!
+!----------------------------------------------------------------------
+  subroutine mpas_modify_att_real1d(attList, attName, attValue, ierr)!{{{
+
+    implicit none
+
+    type (att_list_type), pointer :: attList !< Input/Output: Attribute List
+    character (len=*), intent(in) :: attName !< Input: Att. name to modify
+    real (kind=RKIND), dimension(:), intent(in) :: attValue !< Input: Updated Att. value
+    integer, intent(out), optional :: ierr !< Output: Error flag
+
+    type (att_list_type), pointer :: cursor
+
+    if (present(ierr)) ierr = 1
+
+    ! Traverse list looking for attName
+    cursor => attlist
+    do while (associated(cursor))
+      if (trim(cursor % attName) == trim(attName)) then
+        if (cursor % attType == MPAS_ATT_REALA) then
+          if (size(cursor % attValueRealA) == size(attValue)) then
+            if (present(ierr)) ierr = 0
+            cursor % attValueRealA(:) = attValue(:)
+          end if
+        end if
+        return
+      end if
+      cursor => cursor % next
+    end do
+
+  end subroutine mpas_modify_att_real1d!}}}
 
 !***********************************************************************
 !

--- a/src/framework/mpas_bootstrapping.F
+++ b/src/framework/mpas_bootstrapping.F
@@ -78,14 +78,20 @@ module mpas_bootstrapping
    !-----------------------------------------------------------------------
    subroutine mpas_bootstrap_framework_phase1(domain, mesh_filename, mesh_iotype, pio_file_desc) !{{{
 
+#ifdef MPAS_PIO_SUPPORT
       use pio, only : file_desc_t
+#endif
 
       implicit none
 
       type (domain_type), pointer :: domain
       character(len=*), intent(in) :: mesh_filename
       integer, intent(in) :: mesh_iotype
+#ifdef MPAS_PIO_SUPPORT
       type (file_desc_t), intent(inout), optional :: pio_file_desc
+#else
+      integer, intent(inout), optional :: pio_file_desc
+#endif
 
       type (block_type), pointer :: readingBlock
 
@@ -445,12 +451,18 @@ module mpas_bootstrapping
 
       use mpas_stream_manager
       use mpas_stream_list
+#ifdef MPAS_PIO_SUPPORT
       use pio, only : file_desc_t
+#endif
 
       implicit none
 
       type (domain_type), pointer :: domain
+#ifdef MPAS_PIO_SUPPORT
       type (file_desc_t), intent(inout), optional :: pio_file_desc
+#else
+      integer, intent(inout), optional :: pio_file_desc
+#endif
 
       type (mpas_pool_type), pointer :: readableDimensions
       type (mpas_pool_type), pointer :: streamDimensions

--- a/src/framework/mpas_core_types.inc
+++ b/src/framework/mpas_core_types.inc
@@ -1,4 +1,4 @@
-   abstract interface
+abstract interface
       function mpas_setup_namelist_function(configs, namelistFilename, dminfo) result(iErr)
          use mpas_kind_types
          import mpas_pool_type
@@ -23,7 +23,7 @@
    abstract interface
       function mpas_setup_packages_function(configs, packages, iocontext) result(iErr)
          import mpas_pool_type
-		 import mpas_io_context_type
+         import mpas_io_context_type
 
          type (mpas_pool_type), intent(inout) :: configs
          type (mpas_pool_type), intent(inout) :: packages
@@ -106,15 +106,15 @@
 
    abstract interface
       function mpas_setup_decomposed_dimensions_function(block, streamManager, readDimensions, dimensionPool, totalBlocks) result(iErr)
-		 import block_type
-		 import mpas_streamManager_type
+         import block_type
+         import mpas_streamManager_type
          import mpas_pool_type
 
-		 type (block_type), intent(inout) :: block
-		 type (mpas_streamManager_type), intent(inout) :: streamManager
+         type (block_type), intent(inout) :: block
+         type (mpas_streamManager_type), intent(inout) :: streamManager
          type (mpas_pool_type), intent(inout) :: readDimensions
          type (mpas_pool_type), intent(inout) :: dimensionPool
-		 integer, intent(in) :: totalBlocks
+         integer, intent(in) :: totalBlocks
          integer :: iErr
       end function mpas_setup_decomposed_dimensions_function
    end interface

--- a/src/framework/mpas_derived_types.F
+++ b/src/framework/mpas_derived_types.F
@@ -27,8 +27,14 @@ module mpas_derived_types
 
    use mpas_kind_types
 
+#ifdef MPAS_PIO_SUPPORT
    use pio
    use pio_types
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+   use smiolf, only : SMIOLf_context, SMIOLf_decomp, SMIOLf_file, SMIOL_offset_kind
+#endif
 
    use ESMF
 
@@ -39,6 +45,8 @@ module mpas_derived_types
 #include "mpas_dmpar_types.inc"
 
 #include "mpas_field_types.inc"
+
+#include "mpas_halo_types.inc"
 
 #include "mpas_pool_types.inc"
 

--- a/src/framework/mpas_domain_types.inc
+++ b/src/framework/mpas_domain_types.inc
@@ -15,6 +15,10 @@
       ! Store exchange group information here
       type (mpas_exchange_group), pointer :: exchangeGroups => null()
 
+      ! Storage for halo exchange groups
+      type (mpas_pool_type), pointer :: haloGroupPool => null()   ! Only used internally by mpas_halo module
+      type (mpas_halo_group), pointer :: haloGroups => null()     ! Head pointer of linked list of halo groups
+
       ! Domain specific constants
       logical :: on_a_sphere = .true.
       logical :: is_periodic = .false.

--- a/src/framework/mpas_halo.F
+++ b/src/framework/mpas_halo.F
@@ -1,0 +1,1647 @@
+#define CONTIGUOUS contiguous,
+
+! Copyright (c) 2021-2023 The University Corporation for Atmospheric Research (UCAR).
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at https://mpas-dev.github.io/license.html .
+!
+!-----------------------------------------------------------------------
+!  mpas_halo
+!
+!> \brief Communication of halos for groups of fields
+!> \author Michael Duda
+!> \date   29 September 2021
+!> \details
+!>  This module provides routines for defining groups of fields, and for
+!>  communicating the halos of all fields in a group.
+!
+!-----------------------------------------------------------------------
+module mpas_halo
+
+    implicit none
+
+    private
+
+    public :: mpas_halo_init, &
+              mpas_halo_finalize, &
+              mpas_halo_exch_group_create, &
+              mpas_halo_exch_group_complete, &
+              mpas_halo_exch_group_destroy, &
+              mpas_halo_exch_group_add_field, &
+              mpas_halo_exch_group_full_halo_exch
+
+
+    contains
+
+
+    !-----------------------------------------------------------------------
+    !  routine mpas_halo_init
+    !
+    !> \brief Initialize halo exchange module
+    !> \author Michael Duda
+    !> \date   17 November 2021
+    !> \details
+    !>  This routine initialize the halo exchange module and must be
+    !>  called before any other routine for building or exchanging halos.
+    !
+    !-----------------------------------------------------------------------
+    subroutine mpas_halo_init(domain, iErr)
+
+        use mpas_derived_types, only : domain_type
+        use mpas_pool_routines, only : mpas_pool_create_pool
+
+        ! Arguments
+        type (domain_type), intent(inout) :: domain
+        integer, optional, intent(out) :: iErr
+
+
+        if (present(iErr)) then
+           iErr = 0
+        end if
+
+        call mpas_pool_create_pool(domain % haloGroupPool)
+
+    end subroutine mpas_halo_init
+
+
+    !-----------------------------------------------------------------------
+    !  routine mpas_halo_finalize
+    !
+    !> \brief Finalize halo exchange module
+    !> \author Michael Duda
+    !> \date   17 November 2021
+    !> \details
+    !>  This routine finalize the halo exchange module and must be
+    !>  called after all other calls for building or exchanging halos.
+    !
+    !-----------------------------------------------------------------------
+    subroutine mpas_halo_finalize(domain, iErr)
+
+        use mpas_derived_types, only : domain_type
+        use mpas_pool_routines, only : mpas_pool_destroy_pool
+
+        ! Arguments
+        type (domain_type), intent(inout) :: domain
+        integer, optional, intent(out) :: iErr
+
+
+        if (present(iErr)) then
+           iErr = 0
+        end if
+
+        call mpas_pool_destroy_pool(domain % haloGroupPool)
+
+    end subroutine mpas_halo_finalize
+
+
+    !-----------------------------------------------------------------------
+    !  routine mpas_halo_exch_group_create
+    !
+    !> \brief Create a new group, to which fields can be later added
+    !> \author Michael Duda
+    !> \date   17 November 2021
+    !> \details
+    !>  This routine creates a new group, into which fields can be added by
+    !>  subsequent calls to mpas_halo_exch_group_add_field. After one or more
+    !>  fields have been added to a group created by this routine, a call to
+    !>  mpas_halo_exch_group_complete must be made before the halos of fields
+    !>  in the group can be exchanged with a call to
+    !>  mpas_halo_exch_group_full_halo_exch.
+    !
+    !-----------------------------------------------------------------------
+    subroutine mpas_halo_exch_group_create(domain, groupName, iErr)
+
+        use mpas_derived_types, only : domain_type, mpas_pool_type
+        use mpas_pool_routines, only : mpas_pool_create_pool, mpas_pool_add_subpool
+
+        ! Arguments
+        type (domain_type), intent(inout) :: domain
+        character (len=*), intent(in) :: groupName
+        integer, optional, intent(out) :: iErr
+
+        ! Local variables
+        type (mpas_pool_type), pointer :: newGroup
+
+
+        if (present(iErr)) then
+           iErr = 0
+        end if
+
+        call mpas_pool_create_pool(newGroup)
+        call mpas_pool_add_subpool(domain % haloGroupPool, groupName, newGroup)
+
+    end subroutine mpas_halo_exch_group_create
+
+
+    !-----------------------------------------------------------------------
+    !  routine mpas_halo_exch_group_complete
+    !
+    !> \brief Complete the creation of an exchange group
+    !> \author Michael Duda
+    !> \date   29 September 2021
+    !> \details
+    !>  Complete the creation of an exchange group that was defined via a call
+    !>  to the mpas_halo_exch_group_create routine, and to which fields were
+    !>  added through calls to mpas_halo_exch_group_add_field. This routine
+    !>  must be called for an exchange group before the group can be used in
+    !>  calls to the mpas_halo_exch_group_full_halo_exch routine.
+    !
+    !-----------------------------------------------------------------------
+    subroutine mpas_halo_exch_group_complete(domain, groupName, iErr)
+
+        use mpas_derived_types, only : domain_type, mpas_pool_type, mpas_pool_iterator_type, MPAS_POOL_CONFIG, &
+                                       MPAS_POOL_REAL, MPAS_HALO_REAL, mpas_halo_group, MPAS_LOG_CRIT, &
+                                       field2DReal, field3DReal
+        use mpas_pool_routines, only : mpas_pool_get_subpool, mpas_pool_remove_subpool, mpas_pool_destroy_pool, &
+                                       mpas_pool_begin_iteration, mpas_pool_get_next_member, mpas_pool_get_dimension, &
+                                       mpas_pool_remove_field, mpas_pool_get_field
+        use mpas_log, only : mpas_log_write
+
+        ! Arguments
+        type (domain_type), intent(inout) :: domain
+        character (len=*), intent(in) :: groupName
+        integer, optional, intent(out) :: iErr
+
+        ! Local variables
+        integer :: i
+        type (mpas_pool_type), pointer :: completedGroup
+        type (mpas_pool_iterator_type) :: itr
+        integer, dimension(:), pointer :: fieldHaloInfo
+        integer, dimension(:), pointer :: haloLayers
+        type (mpas_halo_group), pointer :: newGroup
+        type (field2DReal), pointer :: r2d
+        type (field3DReal), pointer :: r3d
+        integer, pointer :: timeLevel
+
+
+        if (present(iErr)) then
+           iErr = 0
+        end if
+
+        call mpas_pool_get_subpool(domain % haloGroupPool, groupName, completedGroup)
+
+        !
+        ! Add new mpas_halo_group to list of haloGroups in domain
+        !
+        allocate(newGroup)
+        newGroup % groupName = groupName
+        newGroup % next => domain % haloGroups
+        domain % haloGroups => newGroup
+
+        !
+        ! Figure out how many fields are in this group
+        !
+        newGroup % nFields = 0
+        call mpas_pool_begin_iteration(completedGroup)
+        do while (mpas_pool_get_next_member(completedGroup, itr))
+            if (itr % memberType == MPAS_POOL_CONFIG) then
+                newGroup % nFields = newGroup % nFields + 1
+            end if
+        end do
+
+        allocate(newGroup % fields(newGroup % nFields))
+
+        !
+        ! Fill in field entries for this group
+        !
+        i = 1
+        call mpas_pool_begin_iteration(completedGroup)
+        do while (mpas_pool_get_next_member(completedGroup, itr))
+            if (itr % memberType == MPAS_POOL_CONFIG) then
+                newGroup % fields(i) % fieldName = trim(itr % memberName)
+
+                call mpas_pool_get_dimension(completedGroup, trim(itr % memberName)//'.info', fieldHaloInfo)
+
+                call mpas_pool_get_dimension(completedGroup, trim(itr % memberName)//'.timelevel', timeLevel)
+
+                call mpas_pool_get_dimension(completedGroup, trim(itr % memberName)//'.layers', haloLayers)
+
+                newGroup % fields(i) % nDims = fieldHaloInfo(2)
+                newGroup % fields(i) % timeLevel = timeLevel
+
+                select case (fieldHaloInfo(1))
+                case (MPAS_POOL_REAL)
+                    newGroup % fields(i) % fieldType = MPAS_HALO_REAL
+                case default
+                    call mpas_log_write('Only real-valued fields are supported in mpas_halo_exch_group_complete', &
+                                        messageType=MPAS_LOG_CRIT)
+                end select
+
+                if (fieldHaloInfo(1) == MPAS_POOL_REAL) then
+                    if (fieldHaloInfo(2) == 2) then
+                        call mpas_pool_get_field(completedGroup, trim(itr % memberName)//'.field', r2d)
+                        call mpas_halo_compact_halo_info(domain, r2d % sendList, r2d % recvList, r2d % dimSizes, &
+                                                         haloLayers, &
+                                                         newGroup % fields(i) % compactHaloInfo, &
+                                                         newGroup % fields(i) % compactSendLists, &
+                                                         newGroup % fields(i) % compactRecvLists)
+                    else if (fieldHaloInfo(2) == 3) then
+                        call mpas_pool_get_field(completedGroup, trim(itr % memberName)//'.field', r3d)
+                        call mpas_halo_compact_halo_info(domain, r3d % sendList, r3d % recvList, r3d % dimSizes, &
+                                                         haloLayers, &
+                                                         newGroup % fields(i) % compactHaloInfo, &
+                                                         newGroup % fields(i) % compactSendLists, &
+                                                         newGroup % fields(i) % compactRecvLists)
+                    else
+                        call mpas_log_write('Unsupported dimensionality for real field in mpas_halo_exch_group_complete.', &
+                                            messageType=MPAS_LOG_CRIT)
+                    end if
+                else
+                    call mpas_log_write('Unsupported field type in mpas_halo_exch_group_complete.', &
+                                        messageType=MPAS_LOG_CRIT)
+                end if
+
+                call mpas_pool_remove_field(completedGroup, trim(itr % memberName)//'.field')
+                i = i + 1
+            end if
+        end do
+
+        call mpas_halo_aggregate_group_info(newGroup)
+
+        !
+        ! Pre-allocate buffers and MPI request lists
+        !
+        allocate(newGroup % sendBuf(newGroup % groupSendBufSize))
+        allocate(newGroup % recvBuf(newGroup % groupRecvBufSize))
+        allocate(newGroup % sendRequests(newGroup % nGroupSendNeighbors))
+        allocate(newGroup % recvRequests(newGroup % nGroupRecvNeighbors))
+
+        call mpas_pool_destroy_pool(completedGroup)
+        call mpas_pool_remove_subpool(domain % haloGroupPool, groupName)
+
+        call refactor_lists(domain, groupName, iErr)
+
+    end subroutine mpas_halo_exch_group_complete
+
+
+    !-----------------------------------------------------------------------
+    !  routine mpas_halo_exch_group_destroy
+    !
+    !> \brief Destroys a halo exchange group
+    !> \author Michael Duda
+    !> \date   17 November 2021
+    !> \details
+    !>  This routine frees memory associated with the named group, which must
+    !>  have been previously created with calls to mpas_halo_exch_group_create
+    !>  and mpas_halo_exch_group_complete.
+    !
+    !-----------------------------------------------------------------------
+    subroutine mpas_halo_exch_group_destroy(domain, groupName, iErr)
+
+        use mpas_derived_types, only : domain_type, mpas_halo_group, MPAS_LOG_CRIT
+        use mpas_log, only : mpas_log_write
+
+        ! Arguments
+        type (domain_type), intent(inout) :: domain
+        character (len=*), intent(in) :: groupName
+        integer, optional, intent(out) :: iErr
+
+        ! Local variables
+        integer :: i
+        type (mpas_halo_group), pointer :: cursor, prev
+
+
+        if (present(iErr)) then
+           iErr = 0
+        end if
+
+        !
+        ! Find this halo exhange group in the list of groups
+        !
+        nullify(prev)
+        cursor => domain % haloGroups
+        do while (associated(cursor))
+            if (trim(cursor % groupName) == trim(groupName)) then
+                exit
+            end if
+
+            prev => cursor
+            cursor => cursor % next
+        end do
+
+        if (.not. associated(cursor)) then
+            call mpas_log_write('Halo exchange group '//trim(groupName)//' not found in destroy routine.', &
+                                messageType=MPAS_LOG_CRIT)
+        end if
+
+        !
+        ! Unlink this exchange group
+        !
+        if (.not. associated(prev)) then
+            domain % haloGroups => cursor % next
+        else
+            prev % next => cursor % next
+        end if
+
+        !
+        ! Deallocate this exchange group
+        !
+        do i = 1, cursor % nFields
+            deallocate(cursor % fields(i) % compactHaloInfo)
+            deallocate(cursor % fields(i) % compactSendLists)
+            deallocate(cursor % fields(i) % compactRecvLists)
+            deallocate(cursor % fields(i) % nSendLists)
+            deallocate(cursor % fields(i) % sendListSrc)
+            deallocate(cursor % fields(i) % sendListDst)
+            deallocate(cursor % fields(i) % packOffsets)
+            deallocate(cursor % fields(i) % nRecvLists)
+            deallocate(cursor % fields(i) % recvListSrc)
+            deallocate(cursor % fields(i) % recvListDst)
+            deallocate(cursor % fields(i) % unpackOffsets)
+        end do
+        deallocate(cursor % fields)
+        deallocate(cursor % groupPackOffsets)
+        deallocate(cursor % groupSendNeighbors)
+        deallocate(cursor % groupSendOffsets)
+        deallocate(cursor % groupSendCounts)
+        deallocate(cursor % groupUnpackOffsets)
+        deallocate(cursor % groupRecvNeighbors)
+        deallocate(cursor % groupToFieldRecvIdx)
+        deallocate(cursor % groupRecvOffsets)
+        deallocate(cursor % groupRecvCounts)
+        deallocate(cursor % sendBuf)
+        deallocate(cursor % recvBuf)
+        deallocate(cursor % sendRequests)
+        deallocate(cursor % recvRequests)
+        deallocate(cursor)
+
+    end subroutine mpas_halo_exch_group_destroy
+
+
+    !-----------------------------------------------------------------------
+    !  routine mpas_halo_exch_group_add_field
+    !
+    !> \brief Add a field to a halo exchange group
+    !> \author Michael Duda
+    !> \date   17 November 2021
+    !> \details
+    !>  This routine adds the field named fieldName to the exchange group named
+    !>  groupName. The timeLevel argument provides control over which time level
+    !>  will be exchanged for the field. If the timeLevel argument is omitted,
+    !>  time level 1 of the field will be exchanged. The haloLayers argument
+    !>  specifies which halo layers will be exchanged for the field; if haloLayers
+    !>  is not specified, all halo layers will be exchanged.
+    !
+    !-----------------------------------------------------------------------
+    subroutine mpas_halo_exch_group_add_field(domain, groupName, fieldName, timeLevel, haloLayers, iErr)
+
+        use mpas_derived_types, only : domain_type, mpas_pool_type, mpas_pool_field_info_type, MPAS_POOL_REAL, &
+                                       field2DReal, field3DReal, MPAS_LOG_CRIT
+        use mpas_pool_routines, only : mpas_pool_get_subpool, mpas_pool_add_config, mpas_pool_get_field_info, &
+                                       mpas_pool_add_dimension, mpas_pool_get_field, mpas_pool_add_field
+        use mpas_log, only : mpas_log_write
+
+        ! Arguments
+        type (domain_type), intent(inout) :: domain
+        character (len=*), intent(in) :: groupName
+        character (len=*), intent(in) :: fieldName
+        integer, optional, intent(in) :: timeLevel
+        integer, dimension(:), optional, intent(in) :: haloLayers
+        integer, optional, intent(out) :: iErr
+
+        ! Local variables
+        type (mpas_pool_type), pointer :: group
+        type (mpas_pool_field_info_type) :: info
+        integer, allocatable, dimension(:) :: fieldHaloInfo
+        integer :: local_timeLevel
+        type (field2DReal), pointer :: r2d
+        type (field3DReal), pointer :: r3d
+
+
+        if (present(iErr)) then
+           iErr = 0
+        end if
+
+        call mpas_pool_get_subpool(domain % haloGroupPool, groupName, group)
+
+        !
+        ! Store an item in the pool to signal the field whose halo is to be exchanged
+        !
+        call mpas_pool_add_config(group, fieldName, 1)
+
+        call mpas_pool_get_field_info(domain % blocklist % allFields, fieldName, info)
+
+        !
+        ! Store an item in the pool with basic info about this field
+        !
+        allocate(fieldHaloInfo(4))
+        fieldHaloInfo(1) = info % fieldType
+        fieldHaloInfo(2) = info % nDims
+        fieldHaloInfo(3) = info % nTimeLevels
+        fieldHaloInfo(4) = info % nHaloLayers
+        call mpas_pool_add_dimension(group, fieldName//'.info', fieldHaloInfo)
+        deallocate(fieldHaloInfo)
+
+        !
+        ! Store an item in the pool with list of halo layers to exchange, or (/-1/) if all layers
+        !
+        if (present(haloLayers)) then
+            call mpas_pool_add_dimension(group, fieldName//'.layers', haloLayers)
+        else
+            call mpas_pool_add_dimension(group, fieldName//'.layers', (/ -1 /))
+        end if
+
+        !
+        ! Store an item in the pool indicating which time level to exchange
+        !
+        if (present(timeLevel)) then
+            local_timeLevel = timeLevel
+        else
+            local_timeLevel = 1
+        end if
+        call mpas_pool_add_dimension(group, fieldName//'.timelevel', local_timeLevel)
+
+        !
+        ! Store a reference to the field itself in the pool
+        !
+        if (info % fieldType == MPAS_POOL_REAL) then
+            if (info % nDims == 2) then
+                call mpas_pool_get_field(domain % blocklist % allFields, fieldName, r2d, timeLevel=local_timeLevel)
+                call mpas_pool_add_field(group, fieldName//'.field', r2d)
+            else if (info % nDims == 3) then
+                call mpas_pool_get_field(domain % blocklist % allFields, fieldName, r3d, timeLevel=local_timeLevel)
+                call mpas_pool_add_field(group, fieldName//'.field', r3d)
+            else
+                call mpas_log_write('Unsupported dimensionality for real field '//trim(fieldName), messageType=MPAS_LOG_CRIT)
+            end if
+        else
+            call mpas_log_write('Unsupported field type for field '//trim(fieldName), messageType=MPAS_LOG_CRIT)
+        end if
+
+    end subroutine mpas_halo_exch_group_add_field
+
+
+    !-----------------------------------------------------------------------
+    !  routine mpas_halo_exch_group_full_halo_exch
+    !
+    !> \brief Communicate halos for all fields in a group
+    !> \author Michael Duda
+    !> \date   15 August 2022
+    !> \details
+    !>  This routine exchanges the halos for all fields in the named halo
+    !>  exchange group.
+    !
+    !-----------------------------------------------------------------------
+    subroutine mpas_halo_exch_group_full_halo_exch(domain, groupName, iErr)
+
+        use mpi
+        use mpas_derived_types, only : domain_type, mpas_halo_group, MPAS_HALO_REAL, MPAS_LOG_CRIT
+        use mpas_pool_routines, only : mpas_pool_get_array
+        use mpas_log, only : mpas_log_write
+
+        ! Parameters
+#ifdef SINGLE_PRECISION
+        integer, parameter :: MPI_REALKIND = MPI_REAL
+#else
+        integer, parameter :: MPI_REALKIND = MPI_DOUBLE_PRECISION
+#endif
+
+        ! Arguments
+        type (domain_type), intent(inout) :: domain
+        character (len=*), intent(in) :: groupName
+        integer, optional, intent(out) :: iErr
+
+        ! Local variables
+        integer :: i, bufstart, bufend
+        integer :: dim1, dim2
+        integer :: i1, i2, j, iNeighbor, iReq
+        integer :: iHalo, iEndp
+        integer :: nHalos, nSendEndpts, nRecvEndpts
+        integer :: rank, comm
+        integer :: mpi_ierr
+        type (mpas_halo_group), pointer :: group
+        integer, dimension(:), pointer :: compactHaloInfo
+        integer, dimension(:), pointer :: compactSendLists
+        integer, dimension(:), pointer :: compactRecvLists
+        integer, dimension(:,:), CONTIGUOUS pointer :: nSendLists
+        integer :: maxNSendList
+        integer, dimension(:,:,:), CONTIGUOUS pointer :: sendListSrc, sendListDst
+        integer, dimension(:), CONTIGUOUS pointer :: packOffsets
+        integer, dimension(:,:), CONTIGUOUS pointer :: nRecvLists
+        integer :: maxNRecvList
+        integer, dimension(:,:,:), CONTIGUOUS pointer :: recvListSrc, recvListDst
+        integer, dimension(:), CONTIGUOUS pointer :: unpackOffsets
+
+
+        if (present(iErr)) then
+           iErr = 0
+        end if
+
+        !
+        ! Find this halo exhange group in the list of groups
+        !
+        group => domain % haloGroups
+        do while (associated(group))
+            if (trim(group % groupName) == trim(groupName)) then
+                exit
+            end if
+
+            group => group % next
+        end do
+
+        if (.not. associated(group)) then
+            call mpas_log_write('Halo exchange group '//trim(groupName)//' not found in full_exch routine.', &
+                                messageType=MPAS_LOG_CRIT)
+        end if
+
+        !
+        ! Get the rank of this task and the MPI communicator to use from the first field in
+        ! the group; all fields should be using the same communicator, so this should not
+        ! be problematic
+        !
+        comm = group % fields(1) % compactHaloInfo(7)
+        rank = group % fields(1) % compactHaloInfo(8)
+
+
+        !
+        ! Initiate non-blocking MPI receives for all neighbors
+        !
+        do i = 1, group % nGroupRecvNeighbors
+            if (group % groupRecvCounts(i) > 0) then
+                bufstart = group % groupRecvOffsets(i)
+                bufend = group % groupRecvOffsets(i) + group % groupRecvCounts(i) - 1
+!TO DO: how do we determine appropriate type here?
+                call MPI_Irecv(group % recvBuf(bufstart:bufend), group % groupRecvCounts(i), MPI_REALKIND, &
+                               group % groupRecvNeighbors(i), group % groupRecvNeighbors(i), comm, &
+                               group % recvRequests(i), mpi_ierr)
+            else
+                group % recvRequests(i) = MPI_REQUEST_NULL
+            end if
+        end do
+
+        !
+        ! Pack the segmented send buffer with elements from all fields and for all neighbors
+        !
+        do i = 1, group % nFields
+
+            compactHaloInfo => group % fields(i) % compactHaloInfo
+            compactSendLists => group % fields(i) % compactSendLists
+
+            !
+            ! Packing code for real-valued fields
+            !
+            if (group % fields(i) % fieldType == MPAS_HALO_REAL) then
+                dim1 = compactHaloInfo(2)
+                dim2 = compactHaloInfo(3)
+
+                nHalos = compactHaloInfo(9)
+                nSendEndpts = compactHaloInfo(10)
+
+                sendListSrc => group % fields(i) % sendListSrc
+                sendListDst => group % fields(i) % sendListDst
+                nSendLists => group % fields(i) % nSendLists
+                packOffsets => group % fields(i) % packOffsets
+                maxNSendList = group % fields(i) % maxNSendList
+
+                select case (group % fields(i) % nDims)
+
+                !
+                ! Packing code for 2-d real-valued fields
+                !
+                case (2)
+                    call mpas_pool_get_array(domain % blocklist % allFields, trim(group % fields(i) % fieldName), &
+                                             group % fields(i) % r2arr, timeLevel=group % fields(i) % timeLevel)
+
+                    !
+                    ! Pack send buffer for all neighbors for current field
+                    !
+                    do iEndp = 1, nSendEndpts
+                        do iHalo = 1, nHalos
+                            do j = 1, maxNSendList
+                                do i1 = 1, dim1
+                                    if (j <= nSendLists(iHalo,iEndp)) then
+                                        group % sendBuf(packOffsets(iEndp) + dim1 * (sendListDst(j,iHalo,iEndp) - 1) + i1) = &
+                                            group % fields(i) % r2arr(i1, sendListSrc(j,iHalo,iEndp))
+                                    end if
+                                end do
+                            end do
+                        end do
+                    end do
+
+                !
+                ! Packing code for 3-d real-valued fields
+                !
+                case (3)
+                    call mpas_pool_get_array(domain % blocklist % allFields, trim(group % fields(i) % fieldName), &
+                                             group % fields(i) % r3arr, group % fields(i) % timeLevel)
+
+                    !
+                    ! Pack send buffer for all neighbors for current field
+                    !
+                    do iEndp = 1, nSendEndpts
+                        do iHalo = 1, nHalos
+                            do j = 1, maxNSendList
+                                do i2 = 1, dim2
+                                do i1 = 1, dim1
+                                    if (j <= nSendLists(iHalo,iEndp)) then
+                                        group % sendBuf(packOffsets(iEndp) + dim1*dim2*(sendListDst(j,iHalo,iEndp) - 1) &
+                                                        + dim1*(i2-1) + i1) = &
+                                            group % fields(i) % r3arr(i1, i2, sendListSrc(j,iHalo,iEndp))
+                                    end if
+                                end do
+                                end do
+                            end do
+                        end do
+                    end do
+
+                end select
+            end if
+        end do
+
+        !
+        ! Initiate non-blocking sends to all neighbors
+        !
+        do i = 1, group % nGroupSendNeighbors
+            if (group % groupSendCounts(i) > 0) then
+                bufstart = group % groupSendOffsets(i)
+                bufend = group % groupSendOffsets(i) + group % groupSendCounts(i) - 1
+!TO DO: how do we determine appropriate type here?
+                call MPI_Isend(group % sendBuf(bufstart:bufend), group % groupSendCounts(i), MPI_REALKIND, &
+                               group % groupSendNeighbors(i), rank, comm, &
+                               group % sendRequests(i), mpi_ierr)
+            else
+                group % sendRequests(i) = MPI_REQUEST_NULL
+            end if
+        end do
+
+        !
+        ! Unpack messages as they are received
+        !
+        do iNeighbor = 1, group % nGroupRecvNeighbors
+
+            call MPI_Waitany(group % nGroupRecvNeighbors, group % recvRequests, iReq, MPI_STATUS_IGNORE, mpi_ierr)
+
+            !
+            ! Unpack the segmented recv buffer with elements for all fields and from all neighbors
+            !
+            do i = 1, group % nFields
+
+                ! Find field-local neighbor index corresponding to the neighbor for which we
+                ! just received a message. If iEndp == 0, then field i does not receive any
+                ! values from neighbor iReq
+                iEndp = group % groupToFieldRecvIdx(iReq, i)
+
+                if (iEndp == 0) cycle     ! No unpacking needed from this neighbor for this field
+
+
+                compactHaloInfo => group % fields(i) % compactHaloInfo
+                compactRecvLists => group % fields(i) % compactRecvLists
+
+                nHalos = compactHaloInfo(9)
+                nRecvEndpts = compactHaloInfo(11)
+
+                recvListSrc => group % fields(i) % recvListSrc
+                recvListDst => group % fields(i) % recvListDst
+                nRecvLists => group % fields(i) % nRecvLists
+                unpackOffsets => group % fields(i) % unpackOffsets
+                maxNRecvList = group % fields(i) % maxNRecvList
+
+
+                !
+                ! Unpacking code for real-valued fields
+                !
+                if (group % fields(i) % fieldType == MPAS_HALO_REAL) then
+                    dim1 = compactHaloInfo(2)
+                    dim2 = compactHaloInfo(3)
+
+                    select case (group % fields(i) % nDims)
+
+                    !
+                    ! Unpacking code for 2-d real-valued fields
+                    !
+                    case (2)
+                        !
+                        ! Unpack recv buffer from all neighbors for current field
+                        !
+                        do iHalo = 1, nHalos
+                            do j = 1, maxNRecvList
+                                do i1 = 1, dim1
+                                    if (j <= nRecvLists(iHalo,iEndp)) then
+                                        group % fields(i) % r2arr(i1, recvListDst(j,iHalo,iEndp)) = &
+                                            group % recvBuf(unpackOffsets(iEndp) + dim1 * (recvListSrc(j,iHalo,iEndp) - 1) + i1)
+                                    end if
+                                end do
+                            end do
+                        end do
+
+                    !
+                    ! Unpacking code for 3-d real-valued fields
+                    !
+                    case (3)
+                        !
+                        ! Unpack recv buffer from all neighbors for current field
+                        !
+                        do iHalo = 1, nHalos
+                            do j = 1, maxNRecvList
+                                do i2 = 1, dim2
+                                do i1 = 1, dim1
+                                    if (j <= nRecvLists(iHalo,iEndp)) then
+                                        group % fields(i) % r3arr(i1, i2, recvListDst(j,iHalo,iEndp)) = &
+                                            group % recvBuf(unpackOffsets(iEndp) + dim1*dim2*(recvListSrc(j,iHalo,iEndp) - 1) &
+                                                            + dim1*(i2-1) + i1)
+                                    end if
+                                end do
+                                end do
+                            end do
+                        end do
+
+                    end select
+                end if
+            end do
+        end do
+
+        !
+        ! Nullify array pointers - not necessary for correctness, but helpful when debugging
+        ! to not leave pointers to what might later be incorrect targets
+        !
+        do i = 1, group % nFields
+            if (group % fields(i) % nDims == 2) then
+                nullify(group % fields(i) % r2arr)
+            else if (group % fields(i) % nDims == 3) then
+                nullify(group % fields(i) % r3arr)
+            end if
+        end do
+
+        !
+        ! Wait for all sends to complete before returning
+        !
+        call MPI_Waitall(group % nGroupSendNeighbors, group % sendRequests, MPI_STATUSES_IGNORE, mpi_ierr)
+
+    end subroutine mpas_halo_exch_group_full_halo_exch
+
+
+    !-----------------------------------------------------------------------
+    !  routine mpas_halo_compact_halo_info
+    !
+    !> \brief Compacts information needed for halo exchanges
+    !> \author Michael Duda
+    !> \date 7 December 2017
+    !> \details
+    !>  This routine extracts all information needed to perform a halo exchange
+    !>  from dynamic data types and places it into a single, contiguous array
+    !>  for use by the mpas_halo_exch_halo_acc routines.
+    !>  The resulting compactHaloInfo array has the following elements:
+    !>    1 - The dimensionality of the field
+    !>    2 - Dimension 1 of the field (i.e., the left-most dimension)
+    !>    3 - Dimension 2 of the field
+    !>    4 - Dimension 3 of the field
+    !>    5 - Dimension 4 of the field
+    !>    6 - Dimension 5 of the field
+    !>    7 - The MPI communicator
+    !>    8 - The MPI rank of the current process
+    !>    9 - The number of halo layers for the field
+    !>   10 - The number of endpoints to send to
+    !>   11 - The number of endpoints to recv from
+    !>
+    !>  The compactSendLists and compactRecvLists arrays have the following elements:
+    !>   foreach (send endpoint) { endPointID foreach (halolayer) {nList srcList(1:nList) destList(1:nList)} }
+    !>   foreach (recv endpoint) { endPointID foreach (halolayer) {nList srcList(1:nList) destList(1:nList)} }
+    !
+    !-----------------------------------------------------------------------
+    subroutine mpas_halo_compact_halo_info(domain, sendList, recvList, dimSizes, haloLayers, &
+                                           compactHaloInfo, compactSendLists, compactRecvLists)
+
+        use mpas_derived_types, only : domain_type, mpas_multihalo_exchange_list, mpas_exchange_list, MPAS_LOG_CRIT
+        use mpas_log, only : mpas_log_write
+
+        implicit none
+
+        ! Arguments
+        type (domain_type), intent(in) :: domain
+        type (mpas_multihalo_exchange_list), pointer :: sendList
+        type (mpas_multihalo_exchange_list), pointer :: recvList
+        integer, dimension(:), intent(in) :: dimsizes
+        integer, dimension(:), intent(in) :: haloLayers
+        integer, dimension(:), pointer :: compactHaloInfo
+        integer, dimension(:), pointer :: compactSendLists
+        integer, dimension(:), pointer :: compactRecvLists
+
+        ! Local variables
+        integer :: i, iendpt, j, ioffset
+        integer :: idx
+        integer :: nSendEndpoints
+        integer :: maxSendEndpoints
+        integer :: totSendListSize
+        integer :: nRecvEndpoints
+        integer :: maxRecvEndpoints
+        integer :: totRecvListSize
+        integer :: nHaloLayers
+        logical :: found
+        integer, allocatable, dimension(:) :: sendEndpoints
+        integer, allocatable, dimension(:) :: recvEndpoints
+        type (mpas_multihalo_exchange_list), pointer :: sendListCursor, recvListCursor
+        type (mpas_exchange_list), pointer :: exchListPtr
+        integer :: activeHaloLayers
+        logical, dimension(:), allocatable :: useHalo
+
+
+        !
+        ! Find number of halo layers
+        !
+        nHaloLayers = size(sendList % halos)
+        if (nHaloLayers /= size(recvList % halos)) then
+            call mpas_log_write('The number of halo layers in the recv list does not match the number in the send list', &
+                                messageType=MPAS_LOG_CRIT)
+        end if
+
+        !
+        ! Create logical array indicating, for each halo layer, whether that halo layer should be
+        ! used in a halo exchange
+        !
+        allocate(useHalo(nHaloLayers))
+
+        if (haloLayers(1) == -1) then     ! Use all halo layers
+            useHalo(:) = .true.
+            activeHaloLayers = nHaloLayers
+        else
+            useHalo(:) = .false.
+            activeHaloLayers = size(haloLayers)
+            do i = 1, activeHaloLayers
+                useHalo(haloLayers(i)) = .true.
+            end do
+        end if
+
+        !
+        ! Find the maximum number of "endpoints" that we will need to send to for any halo layer,
+        ! as well as the total size of the send lists for all halo layers
+        !
+        maxSendEndpoints = 0
+        totSendListSize = 0
+        sendListCursor => sendList
+        do while (associated(sendListCursor))
+            do i=1,nHaloLayers
+                if (useHalo(i)) then
+                    nSendEndpoints = 0
+                    exchListPtr => sendListCursor % halos(i) % exchList
+                    do while (associated(exchListPtr))
+                        nSendEndpoints = nSendEndpoints + 1
+                        totSendListSize = totSendListSize + 2 * exchListPtr % nList    ! We have srcList and destList
+                        exchListPtr => exchListPtr % next
+                    end do
+                    maxSendEndpoints = max(nSendEndpoints, maxSendEndpoints)
+                end if
+            end do
+            sendListCursor => sendListCursor % next     ! Expected to iterate just once for MPAS-Atmosphere
+        end do
+
+        allocate(sendEndpoints(maxSendEndpoints * activeHaloLayers))
+
+        !
+        ! Gather a list of the unique endpoints that we will need to send to
+        !
+        nSendEndpoints = 0
+        sendListCursor => sendList
+        do while (associated(sendListCursor))
+            do i=1,nHaloLayers
+                if (useHalo(i)) then
+                    exchListPtr => sendListCursor % halos(i) % exchList
+                    do while (associated(exchListPtr))
+
+                        ! If the current endpoint is not already in the list, add it
+                        do j=1,nSendEndpoints
+                            if (exchListPtr % endPointID == sendEndpoints(j)) exit
+                        end do
+                        if (j > nSendEndpoints) then
+                            nSendEndpoints = nSendEndpoints + 1
+                            sendEndpoints(nSendEndpoints) = exchListPtr % endPointID
+                        end if
+
+                        exchListPtr => exchListPtr % next
+                    end do
+                end if
+            end do
+            sendListCursor => sendListCursor % next     ! Expected to iterate just once for MPAS-Atmosphere
+        end do
+
+        !
+        ! Find the maximum number of "endpoints" that we will need to receive from for any halo layer,
+        ! as well as the total size of the recv lists for all halo layers
+        !
+        maxRecvEndpoints = 0
+        totRecvListSize = 0
+        recvListCursor => recvList
+        do while (associated(recvListCursor))
+            do i=1,nHaloLayers
+                if (useHalo(i)) then
+                    nRecvEndpoints = 0
+                    exchListPtr => recvListCursor % halos(i) % exchList
+                    do while (associated(exchListPtr))
+                        nRecvEndpoints = nRecvEndpoints + 1
+                        totRecvListSize = totRecvListSize + 2 * exchListPtr % nList    ! We have srcList and destList
+                        exchListPtr => exchListPtr % next
+                    end do
+                    maxRecvEndpoints = max(nRecvEndpoints, maxRecvEndpoints)
+                end if
+            end do
+            recvListCursor => recvListCursor % next     ! Expected to iterate just once for MPAS-Atmosphere
+        end do
+
+        allocate(recvEndpoints(maxRecvEndpoints * activeHaloLayers))
+
+        !
+        ! Gather a list of the unique endpoints that we will need to receive from
+        !
+        nRecvEndpoints = 0
+        recvListCursor => recvList
+        do while (associated(recvListCursor))
+            do i=1,nHaloLayers
+                if (useHalo(i)) then
+                    exchListPtr => recvListCursor % halos(i) % exchList
+                    do while (associated(exchListPtr))
+
+                        ! If the current endpoint is not already in the list, add it
+                        do j=1,nRecvEndpoints
+                            if (exchListPtr % endPointID == recvEndpoints(j)) exit
+                        end do
+                        if (j > nRecvEndpoints) then
+                            nRecvEndpoints = nRecvEndpoints + 1
+                            recvEndpoints(nRecvEndpoints) = exchListPtr % endPointID
+                        end if
+
+                        exchListPtr => exchListPtr % next
+                    end do
+                end if
+            end do
+            recvListCursor => recvListCursor % next     ! Expected to iterate just once for MPAS-Atmosphere
+        end do
+
+
+        !
+        ! Compute the number of elements we will need in compactHaloInfo
+        !
+        allocate(compactHaloInfo(11))
+        allocate(compactSendLists(nSendEndpoints + activeHaloLayers * nSendEndpoints + totSendListSize))
+        allocate(compactRecvLists(nRecvEndpoints + activeHaloLayers * nRecvEndpoints + totRecvListSize))
+
+        compactHaloInfo(:) = 0
+        compactSendLists(:) = 0
+        compactRecvLists(:) = 0
+
+        !
+        ! 1-6: Add field dimensionality and dimensions
+        !
+        compactHaloInfo(1) = size(dimSizes)    ! Dimensionality of the field
+        idx = 2
+        do i=1,compactHaloInfo(1)
+            compactHaloInfo(idx) = dimSizes(i)
+            idx = idx + 1
+        end do
+
+        !
+        ! 7-8: Add MPI info
+        !
+        idx = 7
+        compactHaloInfo(idx) = domain % dminfo % comm
+        idx = idx + 1
+        compactHaloInfo(idx) = domain % dminfo % my_proc_id
+        idx = idx + 1
+
+        !
+        ! 9: Add number of halo layers
+        !
+        compactHaloInfo(idx) = activeHaloLayers
+        idx = idx + 1
+
+        !
+        ! 10: Add number of send endpoints
+        !
+        compactHaloInfo(idx) = nSendEndpoints
+        idx = idx + 1
+
+        !
+        ! 11: Add number of receive endpoints
+        !
+        compactHaloInfo(idx) = nRecvEndpoints
+        idx = idx + 1
+
+        !
+        ! foreach (endpoint) { endPointID foreach (halolayer) {nList srcList(1:nList) destList(1:nList)} }
+        !
+        idx = 1
+        do iendpt=1,nSendEndpoints
+            compactSendLists(idx) = sendEndpoints(iendpt)
+            idx = idx + 1
+            ioffset = 0
+            do i=1,nHaloLayers
+                if (useHalo(i)) then
+                    sendListCursor => sendList
+                    do while (associated(sendListCursor))
+                        found = .false.
+                        exchListPtr => sendListCursor % halos(i) % exchList
+                        do while (associated(exchListPtr))
+                            if (exchListPtr % endPointID == sendEndpoints(iendpt)) then
+                                found = .true.
+                                compactSendLists(idx) = exchListPtr % nList
+                                idx = idx + 1
+                                compactSendLists(idx:idx+exchListPtr % nList-1) = exchListPtr % srcList(1:exchListPtr % nList)
+                                idx = idx + exchListPtr % nList
+                                compactSendLists(idx:idx+exchListPtr % nList-1) = exchListPtr % destList(1:exchListPtr % nList) + &
+                                                                                  ioffset
+                                idx = idx + exchListPtr % nList
+                                ioffset = ioffset + exchListPtr % nList
+                                exit
+                            end if
+                            exchListPtr => exchListPtr % next
+                        end do
+                        if (.not. found) then
+                            compactSendLists(idx) = 0
+                            idx = idx + 1
+                        end if
+                        sendListCursor => sendListCursor % next     ! Expected to iterate just once for MPAS-Atmosphere
+                    end do
+                end if
+            end do
+        end do
+
+        deallocate(sendEndpoints)
+
+        !
+        ! foreach (endpoint) { endPointID foreach (halolayer) {nList srcList(1:nList) destList(1:nList)} }
+        !
+        idx = 1
+        do iendpt=1,nRecvEndpoints
+            compactRecvLists(idx) = recvEndpoints(iendpt)
+            idx = idx + 1
+            ioffset = 0
+            do i=1,nHaloLayers
+                if (useHalo(i)) then
+                    recvListCursor => recvList
+                    do while (associated(recvListCursor))
+                        found = .false.
+                        exchListPtr => recvListCursor % halos(i) % exchList
+                        do while (associated(exchListPtr))
+                            if (exchListPtr % endPointID == recvEndpoints(iendpt)) then
+                                found = .true.
+                                compactRecvLists(idx) = exchListPtr % nList
+                                idx = idx + 1
+                                compactRecvLists(idx:idx+exchListPtr % nList-1) = exchListPtr % srcList(1:exchListPtr % nList) + &
+                                                                                  ioffset
+                                idx = idx + exchListPtr % nList
+                                compactRecvLists(idx:idx+exchListPtr % nList-1) = exchListPtr % destList(1:exchListPtr % nList)
+                                idx = idx + exchListPtr % nList
+                                ioffset = ioffset + exchListPtr % nList
+                                exit
+                            end if
+                            exchListPtr => exchListPtr % next
+                        end do
+                        if (.not. found) then
+                            compactRecvLists(idx) = 0
+                            idx = idx + 1
+                        end if
+                        recvListCursor => recvListCursor % next     ! Expected to iterate just once for MPAS-Atmosphere
+                    end do
+                end if
+            end do
+        end do
+
+        deallocate(recvEndpoints)
+
+        deallocate(useHalo)
+
+    end subroutine mpas_halo_compact_halo_info
+
+
+    !-----------------------------------------------------------------------
+    !  routine mpas_halo_aggregate_group_info
+    !
+    !> \brief Aggregate exchange info from all fields in a halo exchange group
+    !> \author Michael Duda
+    !> \date   23 November 2021
+    !> \details
+    !>  Given an mpas_halo_group, this routine aggregates information from across
+    !>  all mpas_halo_field members of the group.
+    !>  The end result of this routine is a set of arrays that can be used by
+    !>  the mpas_halo_exch_group_full_halo_exch routine to pack/unpack buffers
+    !>  and launch MPI sends and receives:
+    !>
+    !>    nGroupSendNeighbors
+    !>    groupSendBufSize
+    !>    groupPackOffsets
+    !>    groupSendNeighbors
+    !>    groupSendOffsets
+    !>    groupSendCounts
+    !>
+    !>    nGroupRecvNeighbors
+    !>    groupRecvBufSize
+    !>    groupUnpackOffsets
+    !>    groupRecvNeighbors
+    !>    groupToFieldRecvEndpt
+    !>    groupRecvOffsets
+    !>    groupRecvCounts
+    !
+    !-----------------------------------------------------------------------
+    subroutine mpas_halo_aggregate_group_info(group, ierr)
+
+        use mpas_derived_types, only : mpas_halo_group
+
+        ! Arguments
+        type (mpas_halo_group), intent(inout) :: group
+        integer, intent(out), optional :: ierr
+
+        ! Local variables
+        integer :: i, j, idx, ihalo, iendp, nlist
+        integer :: ndims, ninnerelems
+        integer :: maxGroupSendNeighbors, maxGroupRecvNeighbors
+        integer, allocatable, dimension(:) :: sendNeighbors, recvNeighbors
+        integer, allocatable, dimension(:,:) :: sendCounts, recvCounts
+
+
+        if (present(ierr)) then
+            ierr = 0
+        end if
+
+        !
+        ! Compute an upper bound on the number of send and recv neighbors for this group
+        !
+        maxGroupSendNeighbors = 0
+        maxGroupRecvNeighbors = 0
+        do i = 1, group % nFields
+            maxGroupSendNeighbors = maxGroupSendNeighbors + group % fields(i) % compactHaloInfo(10)
+            maxGroupRecvNeighbors = maxGroupRecvNeighbors + group % fields(i) % compactHaloInfo(11)
+        end do
+
+
+        !
+        ! Create a list of unique send and recv neighbors for this group
+        !
+        allocate(sendNeighbors(maxGroupSendNeighbors))
+        allocate(recvNeighbors(maxGroupRecvNeighbors))
+
+        sendNeighbors(:) = -1
+        recvNeighbors(:) = -1
+
+        group % nGroupSendNeighbors = 0
+        group % nGroupRecvNeighbors = 0
+
+        do i = 1, group % nFields
+            idx = 1
+            do iendp = 1, group % fields(i) % compactHaloInfo(10)
+
+                ! Try to locate this endPointID in the list
+                do j = 1, group % nGroupSendNeighbors
+                    if (sendNeighbors(j) == group % fields(i) % compactSendLists(idx)) then
+                        exit
+                    end if
+                end do
+
+                ! If endPointID was not found, add it to the list
+                if (j > group % nGroupSendNeighbors) then
+                    group % nGroupSendNeighbors = group % nGroupSendNeighbors + 1
+                    sendNeighbors(group % nGroupSendNeighbors) = group % fields(i) % compactSendLists(idx)
+                end if
+
+                ! Skip over remaining info for this endpoint
+                idx = idx + 1                ! skip over endPointID
+                do ihalo = 1, group % fields(i) % compactHaloInfo(9)
+                    nlist = group % fields(i) % compactSendLists(idx)
+                    idx = idx + 1            ! skip over nList
+                    idx = idx + 2 * nlist    ! skip over srcList and destList
+                end do
+            end do
+
+            idx = 1
+            do iendp = 1, group % fields(i) % compactHaloInfo(11)
+
+                ! Try to locate this endPointID in the list
+                do j = 1, group % nGroupRecvNeighbors
+                    if (recvNeighbors(j) == group % fields(i) % compactRecvLists(idx)) then
+                        exit
+                    end if
+                end do
+
+                ! If endPointID was not found, add it to the list
+                if (j > group % nGroupRecvNeighbors) then
+                    group % nGroupRecvNeighbors = group % nGroupRecvNeighbors + 1
+                    recvNeighbors(group % nGroupRecvNeighbors) = group % fields(i) % compactRecvLists(idx)
+                end if
+
+                ! Skip over remaining info for this endpoint
+                idx = idx + 1                ! skip over endPointID
+                do ihalo = 1, group % fields(i) % compactHaloInfo(9)
+                    nlist = group % fields(i) % compactRecvLists(idx)
+                    idx = idx + 1            ! skip over nList
+                    idx = idx + 2 * nlist    ! skip over srcList and destList
+                end do
+            end do
+
+        end do
+
+        allocate(group % groupSendNeighbors(group % nGroupSendNeighbors))
+        group % groupSendNeighbors(:) = sendNeighbors(1:group % nGroupSendNeighbors)
+
+        allocate(group % groupRecvNeighbors(group % nGroupRecvNeighbors))
+        group % groupRecvNeighbors(:) = recvNeighbors(1:group % nGroupRecvNeighbors)
+
+        allocate(group % groupToFieldRecvIdx(group % nGroupRecvNeighbors, group % nFields))
+        group % groupToFieldRecvIdx(:,:) = 0
+
+        deallocate(sendNeighbors)
+        deallocate(recvNeighbors)
+
+
+        !
+        ! Compute total size of send and receive buffers for this group
+        !
+        group % groupSendBufSize = 0
+        group % groupRecvBufSize = 0
+
+        do i = 1, group % nFields
+
+            ndims = group % fields(i) % compactHaloInfo(1)
+            ninnerelems = 1
+            do j = 1, ndims - 1    ! Do not include right-most dimension (nCells, nEdges, or nVertices)
+                ninnerelems = ninnerelems * group % fields(i) % compactHaloInfo(j + 1)    ! First dim is at (2), etc.
+            end do
+
+            idx = 1
+            do iendp = 1, group % fields(i) % compactHaloInfo(10)
+
+                idx = idx + 1                ! skip over endPointID
+                do ihalo = 1, group % fields(i) % compactHaloInfo(9)
+                    nlist = group % fields(i) % compactSendLists(idx)
+                    group % groupSendBufSize = group % groupSendBufSize + ninnerelems * nlist
+
+                    idx = idx + 1            ! skip over nList
+                    idx = idx + 2 * nlist    ! skip over srcList and destList
+                end do
+            end do
+
+            idx = 1
+            do iendp = 1, group % fields(i) % compactHaloInfo(11)
+
+                idx = idx + 1                ! skip over endPointID
+                do ihalo = 1, group % fields(i) % compactHaloInfo(9)
+                    nlist = group % fields(i) % compactRecvLists(idx)
+                    group % groupRecvBufSize = group % groupRecvBufSize + ninnerelems * nlist
+
+                    idx = idx + 1            ! skip over nList
+                    idx = idx + 2 * nlist    ! skip over srcList and destList
+                end do
+            end do
+
+        end do
+
+
+        !
+        ! Compute sizes and offsets in group send and recv buffers for all fields in group
+        !
+        allocate(group % groupPackOffsets(group % nGroupSendNeighbors, group % nFields))
+        allocate(group % groupSendOffsets(group % nGroupSendNeighbors))
+        allocate(group % groupSendCounts(group % nGroupSendNeighbors))
+        group % groupPackOffsets(:,:) = -1
+        group % groupSendOffsets(:) = -1
+        group % groupSendCounts(:) = -1
+
+        allocate(group % groupUnpackOffsets(group % nGroupRecvNeighbors, group % nFields))
+        allocate(group % groupRecvOffsets(group % nGroupRecvNeighbors))
+        allocate(group % groupRecvCounts(group % nGroupRecvNeighbors))
+        group % groupUnpackOffsets(:,:) = -1
+        group % groupRecvOffsets(:) = -1
+        group % groupRecvCounts(:) = -1
+
+        allocate(sendCounts(group % nGroupSendNeighbors, group % nFields))
+        allocate(recvCounts(group % nGroupRecvNeighbors, group % nFields))
+        sendCounts(:,:) = 0
+        recvCounts(:,:) = 0
+
+        do i = 1, group % nFields
+
+            ndims = group % fields(i) % compactHaloInfo(1)
+            ninnerelems = 1
+            do j = 1, ndims - 1    ! Do not include right-most dimension (nCells, nEdges, or nVertices)
+                ninnerelems = ninnerelems * group % fields(i) % compactHaloInfo(j + 1)    ! First dim is at (2), etc.
+            end do
+
+            idx = 1
+            do iendp = 1, group % fields(i) % compactHaloInfo(10)
+
+                ! Find neighbor in groupSendNeighbors
+                do j = 1, group % nGroupSendNeighbors
+                    if (group % fields(i) % compactSendLists(idx) == group % groupSendNeighbors(j)) then
+                        exit
+                    end if
+                end do
+
+                idx = idx + 1                ! skip over endPointID
+                sendCounts(j, i) = 0
+                do ihalo = 1, group % fields(i) % compactHaloInfo(9)
+                    nlist = group % fields(i) % compactSendLists(idx)
+                    sendCounts(j, i) = sendCounts(j, i) + nlist * ninnerelems
+
+                    idx = idx + 1            ! skip over nList
+                    idx = idx + 2 * nlist    ! skip over srcList and destList
+                end do
+            end do
+
+            idx = 1
+            do iendp = 1, group % fields(i) % compactHaloInfo(11)
+
+                ! Find neighbor in groupRecvNeighbors
+                do j = 1, group % nGroupRecvNeighbors
+                    if (group % fields(i) % compactRecvLists(idx) == group % groupRecvNeighbors(j)) then
+                        group % groupToFieldRecvIdx(j, i) = iendp
+                        exit
+                    end if
+                end do
+
+                idx = idx + 1                ! skip over endPointID
+                recvCounts(j, i) = 0
+                do ihalo = 1, group % fields(i) % compactHaloInfo(9)
+                    nlist = group % fields(i) % compactRecvLists(idx)
+                    recvCounts(j, i) = recvCounts(j, i) + nlist * ninnerelems
+
+                    idx = idx + 1            ! skip over nList
+                    idx = idx + 2 * nlist    ! skip over srcList and destList
+                end do
+            end do
+
+        end do
+
+        do j = 1, group % nGroupSendNeighbors
+            group % groupPackOffsets(j, 1) = 0
+            do i = 2, group % nFields
+                group % groupPackOffsets(j, i) = group % groupPackOffsets(j, i-1) + sendCounts(j, i-1)
+            end do
+        end do
+
+        do j = 1, group % nGroupRecvNeighbors
+            group % groupUnpackOffsets(j, 1) = 0
+            do i = 2, group % nFields
+                group % groupUnpackOffsets(j, i) = group % groupUnpackOffsets(j, i-1) + recvCounts(j, i-1)
+            end do
+        end do
+
+        do j = 1, group % nGroupSendNeighbors
+            group % groupSendCounts(j) = 0
+            do i = 1, group % nFields
+                group % groupSendCounts(j) = group % groupSendCounts(j) + sendCounts(j, i)
+            end do
+
+            if (j == 1) then
+                group % groupSendOffsets(j) = 1
+            else
+                group % groupSendOffsets(j) = group % groupSendOffsets(j-1) + group % groupSendCounts(j-1)
+
+                do i = 1, group % nFields
+                    group % groupPackOffsets(j, i) = group % groupPackOffsets(j, i) + group % groupSendOffsets(j) - 1
+                end do
+            end if
+        end do
+
+        do j = 1, group % nGroupRecvNeighbors
+            group % groupRecvCounts(j) = 0
+            do i = 1, group % nFields
+                group % groupRecvCounts(j) = group % groupRecvCounts(j) + recvCounts(j, i)
+            end do
+
+            if (j == 1) then
+                group % groupRecvOffsets(j) = 1
+            else
+                group % groupRecvOffsets(j) = group % groupRecvOffsets(j-1) + group % groupRecvCounts(j-1)
+
+                do i = 1, group % nFields
+                    group % groupUnpackOffsets(j, i) = group % groupUnpackOffsets(j, i) + group % groupRecvOffsets(j) - 1
+                end do
+            end if
+        end do
+
+        deallocate(sendCounts)
+        deallocate(recvCounts)
+
+    end subroutine mpas_halo_aggregate_group_info
+
+
+    !-----------------------------------------------------------------------
+    !  routine refactor_lists
+    !
+    !> \brief Convert compact{Send,Recv}Lists into multi-dimensional arrays
+    !> \author Michael Duda
+    !> \date   25 May 2022
+    !> \details
+    !>  For each field in the halo exchange group identified by groupName,
+    !>  convert the compact{Send,Recv}Lists 1-d arrays into multi-dimensional
+    !>  arrays that allow for more optimal pack and unpack loops in the
+    !>  mpas_halo_exch_group_full_halo_exch routine.
+    !>
+    !>  The following members in the mpas_halo_field type are allocated and
+    !>  set by this routine:
+    !>
+    !>    nSendLists
+    !>    maxNSendList
+    !>    sendListSrc
+    !>    sendListDst
+    !>    packOffsets
+    !>
+    !>    nRecvLists
+    !>    maxNRecvList
+    !>    recvListSrc
+    !>    recvListDst
+    !>    unpackOffsets
+    !
+    !-----------------------------------------------------------------------
+    subroutine refactor_lists(domain, groupName, iErr)
+
+        use mpas_derived_types, only : domain_type, mpas_halo_group, MPAS_HALO_REAL, MPAS_LOG_CRIT
+        use mpas_pool_routines, only : mpas_pool_get_array
+        use mpas_log, only : mpas_log_write
+
+        ! Arguments
+        type (domain_type), intent(inout) :: domain
+        character (len=*), intent(in) :: groupName
+        integer, optional, intent(out) :: iErr
+
+        ! Local variables
+        integer :: i
+        integer :: iNeighbor, j
+        integer :: iHalo, iEndp
+        integer :: nHalos, nSendEndpts, nRecvEndpts
+        integer :: idx, idx_local
+        type (mpas_halo_group), pointer :: group
+        integer, dimension(:), pointer :: compactHaloInfo
+        integer, dimension(:), pointer :: compactSendLists
+        integer, dimension(:), pointer :: compactRecvLists
+        integer :: maxNSendList
+        integer, dimension(:,:), CONTIGUOUS pointer :: nSendLists
+        integer, dimension(:,:,:), CONTIGUOUS pointer :: sendListSrc, sendListDst
+        integer, dimension(:), CONTIGUOUS pointer :: packOffsets
+        integer :: maxNRecvList
+        integer, dimension(:,:), CONTIGUOUS pointer :: nRecvLists
+        integer, dimension(:,:,:), CONTIGUOUS pointer :: recvListSrc, recvListDst
+        integer, dimension(:), CONTIGUOUS pointer :: unpackOffsets
+
+
+        if (present(iErr)) then
+           iErr = 0
+        end if
+
+        !
+        ! Find this halo exhange group in the list of groups
+        !
+        group => domain % haloGroups
+        do while (associated(group))
+            if (trim(group % groupName) == trim(groupName)) then
+                exit
+            end if
+
+            group => group % next
+        end do
+
+        if (.not. associated(group)) then
+            call mpas_log_write('Halo exchange group '//trim(groupName)//' not found in refactor_lists.', &
+                                messageType=MPAS_LOG_CRIT)
+        end if
+
+
+        !
+        ! Pack the segmented send buffer with elements from all fields and for all neighbors
+        !
+        do i = 1, group % nFields
+
+            compactHaloInfo => group % fields(i) % compactHaloInfo
+            compactSendLists => group % fields(i) % compactSendLists
+
+            !
+            ! Packing code for real-valued fields
+            !
+            if (group % fields(i) % fieldType == MPAS_HALO_REAL) then
+                nHalos = compactHaloInfo(9)
+                nSendEndpts = compactHaloInfo(10)
+                idx = 1
+
+                allocate(group % fields(i) % nSendLists(3,nSendEndpts))    ! MGD fix hard-coded 3 later...
+                allocate(group % fields(i) % packOffsets(nSendEndpts))
+
+                nSendLists => group % fields(i) % nSendLists
+                packOffsets => group % fields(i) % packOffsets
+
+                nSendLists(:,:) = 0
+                packOffsets(:) = 0
+
+                idx_local = idx
+
+                do iEndp = 1, nSendEndpts
+                    ! Find this endpoint in the list of neighbors
+                    do iNeighbor = 1, group % nGroupSendNeighbors
+                        if (group % groupSendNeighbors(iNeighbor) == compactSendLists(idx)) exit
+                    end do
+                    idx = idx + 1
+
+                    packOffsets(iEndp) = group % groupPackOffsets(iNeighbor, i)
+
+                    do iHalo = 1, nHalos
+                        nSendLists(iHalo,iEndp) = compactSendLists(idx)
+                        idx = idx + 1
+                        idx = idx + 2*nSendLists(iHalo,iEndp)
+                    end do
+                end do
+
+                maxNSendList = maxval(nSendLists)
+                group % fields(i) % maxNSendList = maxNSendList
+
+                allocate(group % fields(i) % sendListSrc(maxNSendList,nHalos,nSendEndpts))
+                allocate(group % fields(i) % sendListDst(maxNSendList,nHalos,nSendEndpts))
+
+                sendListSrc => group % fields(i) % sendListSrc
+                sendListDst => group % fields(i) % sendListDst
+
+                sendListSrc(:,:,:) = 0
+                sendListDst(:,:,:) = 0
+
+                idx = idx_local
+
+                do iEndp = 1, nSendEndpts
+                    idx = idx + 1
+
+                    do iHalo = 1, nHalos
+                        idx = idx + 1
+                        do j = 1, nSendLists(iHalo,iEndp)
+                            sendListSrc(j,iHalo,iEndp) = compactSendLists(idx + j - 1)
+                            sendListDst(j,iHalo,iEndp) = compactSendLists(idx + nSendLists(iHalo,iEndp) + j - 1)
+                        end do
+                        idx = idx + 2*nSendLists(iHalo,iEndp)
+                    end do
+                end do
+
+            end if
+        end do
+
+
+        !
+        ! Unpack the segmented recv buffer with elements for all fields and from all neighbors
+        !
+        do i = 1, group % nFields
+
+            compactHaloInfo => group % fields(i) % compactHaloInfo
+            compactRecvLists => group % fields(i) % compactRecvLists
+
+            idx = 1
+
+            !
+            ! Unpacking code for real-valued fields
+            !
+            if (group % fields(i) % fieldType == MPAS_HALO_REAL) then
+                nHalos = compactHaloInfo(9)
+                nRecvEndpts = compactHaloInfo(11)
+                idx = 1
+
+                allocate(group % fields(i) % nRecvLists(3,nRecvEndpts))    ! MGD fix hard-coded 3 later...
+                allocate(group % fields(i) % unpackOffsets(nRecvEndpts))
+
+                nRecvLists => group % fields(i) % nRecvLists
+                unpackOffsets => group % fields(i) % unpackOffsets
+
+                nRecvLists(:,:) = 0
+                unpackOffsets(:) = 0
+
+                idx_local = idx
+
+                do iEndp = 1, nRecvEndpts
+                    ! Find this endpoint in the list of neighbors
+                    do iNeighbor = 1, group % nGroupRecvNeighbors
+                        if (group % groupRecvNeighbors(iNeighbor) == compactRecvLists(idx)) exit
+                    end do
+                    idx = idx + 1
+
+                    unpackOffsets(iEndp) = group % groupUnpackOffsets(iNeighbor, i)
+
+                    do iHalo = 1, nHalos
+                        nRecvLists(iHalo,iEndp) = compactRecvLists(idx)
+                        idx = idx + 1
+                        idx = idx + 2*nRecvLists(iHalo,iEndp)
+                    end do
+                end do
+
+                maxNRecvList = maxval(nRecvLists)
+                group % fields(i) % maxNRecvList = maxNRecvList
+
+                allocate(group % fields(i) % recvListSrc(maxNRecvList,nHalos,nRecvEndpts))
+                allocate(group % fields(i) % recvListDst(maxNRecvList,nHalos,nRecvEndpts))
+
+                recvListSrc => group % fields(i) % recvListSrc
+                recvListDst => group % fields(i) % recvListDst
+
+                recvListSrc(:,:,:) = 0
+                recvListDst(:,:,:) = 0
+
+                idx = idx_local
+
+                do iEndp = 1, nRecvEndpts
+                    idx = idx + 1
+
+                    do iHalo = 1, nHalos
+                        idx = idx + 1
+                        do j = 1, nRecvLists(iHalo,iEndp)
+                            recvListSrc(j,iHalo,iEndp) = compactRecvLists(idx + j - 1)
+                            recvListDst(j,iHalo,iEndp) = compactRecvLists(idx + nRecvLists(iHalo,iEndp) + j - 1)
+                        end do
+                        idx = idx + 2*nRecvLists(iHalo,iEndp)
+                    end do
+                end do
+
+            end if
+        end do
+
+    end subroutine refactor_lists
+
+end module mpas_halo

--- a/src/framework/mpas_halo_types.inc
+++ b/src/framework/mpas_halo_types.inc
@@ -1,0 +1,77 @@
+#define CONTIGUOUS contiguous,
+
+    integer, parameter :: MPAS_HALO_INVALID   = -1
+
+    integer, parameter :: MPAS_HALO_REAL      = 5001, &
+                          MPAS_HALO_INTEGER   = 5002
+
+
+    !
+    ! Information about an individual field in a halo group
+    !
+    type mpas_halo_field
+        character(len=StrKIND) :: fieldName = ''      ! Name of the field
+        integer :: nDims = MPAS_HALO_INVALID          ! Number of dimensions for field
+        integer :: fieldType = MPAS_HALO_INVALID      ! Field type: MPAS_HALO_REAL, MPAS_HALO_INTEGER
+        integer :: timeLevel = MPAS_HALO_INVALID      ! Which time level to exchange
+
+        integer, dimension(:), pointer :: compactHaloInfo => null()      ! Information about halo communication for this field
+        integer, dimension(:), pointer :: compactSendLists => null()     ! Elements sent to each neighbor
+        integer, dimension(:), pointer :: compactRecvLists => null()     ! Elements received from each neighbor
+
+        integer, dimension(:,:), CONTIGUOUS pointer :: nSendLists => null()     ! (3,nSendEndpoints) 3 is assumed max halos
+        integer :: maxNSendList                                                 ! maxval(nSendLists)
+        integer, dimension(:,:,:), CONTIGUOUS pointer :: sendListSrc => null()  ! (maxNSendList,nHalos,nSendEndpts)
+        integer, dimension(:,:,:), CONTIGUOUS pointer :: sendListDst => null()  ! (maxNSendList,nHalos,nSendEndpts)
+        integer, dimension(:), CONTIGUOUS pointer :: packOffsets => null()      ! (nSendEndpts)
+
+        integer, dimension(:,:), CONTIGUOUS pointer :: nRecvLists => null()     ! (3,nRecvEndpoints) 3 is assumed max halos
+        integer :: maxNRecvList                                                 ! maxval(nRecvLists)
+        integer, dimension(:,:,:), CONTIGUOUS pointer :: recvListSrc => null()  ! (maxNRecvList,nHalos,nRecvEndpts)
+        integer, dimension(:,:,:), CONTIGUOUS pointer :: recvListDst => null()  ! (maxNRecvList,nHalos,nRecvEndpts)
+        integer, dimension(:), CONTIGUOUS pointer :: unpackOffsets => null()    ! (nRecvEndpts)
+
+        real (kind=RKIND), dimension(:,:), pointer :: r2arr => null()    ! Pointer to field array, only used internally
+        real (kind=RKIND), dimension(:,:,:), pointer :: r3arr => null()  ! Pointer to field array, only used internally
+    end type mpas_halo_field
+
+
+    !
+    ! Information about an entire halo group
+    !
+    type mpas_halo_group
+        character(len=StrKIND) :: groupName = ''                           ! Name of the group
+        integer :: nFields = MPAS_HALO_INVALID                             ! Number of fields in the group
+        type (mpas_halo_field), dimension(:), pointer :: fields => null()  ! Array of field halo info types, dimensioned nFields
+
+        integer :: nGroupSendNeighbors = MPAS_HALO_INVALID                ! Number of unique neighbors that we send to
+        integer :: groupSendBufSize = MPAS_HALO_INVALID                   ! Total number of elements to be sent in a group exchange
+        real (kind=RKIND), dimension(:), pointer :: sendBuf => null()     ! Segmented buffer used for outgoing messages
+        integer, dimension(:), pointer :: sendRequests => null()          ! Used internally - MPI request IDs
+        integer, dimension(:,:), pointer :: groupPackOffsets => null()    ! Offsets into sendBuf for each neighbor and each field
+                                                                          !     dimensioned (nGroupSendNeighbors, nFields)
+        integer, dimension(:), pointer :: groupSendNeighbors => null()    ! List of neighbors we send to
+                                                                          !     dimensioned (nGroupSendNeighbors)
+        integer, dimension(:), pointer :: groupSendOffsets => null()      ! Offset in sendBuf of segment to send to each neighbor
+                                                                          !     dimensioned (nGroupSendNeighbors)
+        integer, dimension(:), pointer :: groupSendCounts => null()       ! Size of sendBuf segment to send to each neighbor
+                                                                          !     dimensioned (nGroupSendNeighbors)
+
+        integer :: nGroupRecvNeighbors = MPAS_HALO_INVALID                ! Number of unique neighbors that we recv from
+        integer :: groupRecvBufSize = MPAS_HALO_INVALID                   ! Total number of elements to be recvd in a group exchange
+        real (kind=RKIND), dimension(:), pointer :: recvBuf => null()     ! Segmented buffer used for incoming messages
+        integer, dimension(:), pointer :: recvRequests => null()          ! Used internally - MPI request IDs
+        integer, dimension(:,:), pointer :: groupUnpackOffsets => null()  ! Offsets into recvBuf for each neighbor and each field
+                                                                          !     dimensioned (nGroupRecvNeighbors, nFields)
+        integer, dimension(:), pointer :: groupRecvNeighbors => null()    ! List of neighbors we recv from
+                                                                          !     dimensioned (nGroupRecvNeighbors)
+        integer, dimension(:,:), pointer :: groupToFieldRecvIdx => null() ! Convert from group-wide neighbor indices to
+                                                                          !     field-local indices
+                                                                          !     dimensioned (nGroupRecvNeighbors, nFields)
+        integer, dimension(:), pointer :: groupRecvOffsets => null()      ! Offset in recvBuf of segment to recv from each neighbor
+                                                                          !     dimensioned (nGroupRecvNeighbors)
+        integer, dimension(:), pointer :: groupRecvCounts => null()       ! Size of recvBuf segment to recv from each neighbor
+                                                                          !     dimensioned (nGroupRecvNeighbors)
+
+        type (mpas_halo_group), pointer :: next => null()    ! Pointer to the next halo group
+    end type mpas_halo_group

--- a/src/framework/mpas_io.F
+++ b/src/framework/mpas_io.F
@@ -12,6 +12,7 @@ module mpas_io
    use mpas_dmpar
    use mpas_log
 
+#ifdef MPAS_PIO_SUPPORT
    use pio
    use piolib_mod
    use pionfatt_mod
@@ -22,7 +23,19 @@ module mpas_io
 #else
    integer, parameter :: PIO_REALKIND = PIO_DOUBLE
 #endif
+#endif
 
+#ifdef MPAS_SMIOL_SUPPORT
+   use SMIOLf
+
+#include "smiol_codes.inc"
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
+
+   !
+   ! PIO-based fill values
+   !
 #ifdef USE_PIO2
    integer, parameter :: MPAS_INT_FILLVAL = PIO_FILL_INT
    character, parameter :: MPAS_CHAR_FILLVAL = achar(0)  ! TODO: To be replaced with PIO_FILL_CHAR once PIO2 provides this variable
@@ -45,7 +58,36 @@ module mpas_io
 #endif
 #endif
 
-   integer, private :: pio_global_ierr = PIO_noerr
+#else
+
+#ifdef MPAS_SMIOL_SUPPORT
+
+   !
+   ! SMIOL-based fill values
+   !
+   integer, parameter :: MPAS_INT_FILLVAL = huge(0)
+   character, parameter :: MPAS_CHAR_FILLVAL = achar(0)
+   real (kind=RKIND), parameter :: MPAS_REAL_FILLVAL = huge(0.0_RKIND)
+
+#else
+
+   !
+   ! Default fill values
+   !
+   integer, parameter :: MPAS_INT_FILLVAL = huge(1)
+   character, parameter :: MPAS_CHAR_FILLVAL = achar(0)
+   real (kind=RKIND), parameter :: MPAS_REAL_FILLVAL = huge(1.0_RKIND)
+
+#endif
+
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
+   integer, private :: io_global_err = PIO_noerr
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+   integer, private :: io_global_err = SMIOL_SUCCESS
+#endif
 
    interface MPAS_io_get_var
       module procedure MPAS_io_get_var_int0d
@@ -105,7 +147,11 @@ module mpas_io
       type (mpas_io_context_type), intent(inout) :: ioContext
       integer, intent(in) :: io_task_count
       integer, intent(in) :: io_task_stride
+#ifdef MPAS_PIO_SUPPORT
       type (iosystem_desc_t), optional, pointer :: io_system
+#else
+      integer, optional, pointer :: io_system
+#endif
       integer, intent(out), optional :: ierr
 
       integer :: local_ierr
@@ -116,7 +162,9 @@ module mpas_io
       if (present(ierr)) ierr = MPAS_IO_NOERR
 
       if (present(io_system)) then
+#ifdef MPAS_PIO_SUPPORT
          ioContext % pio_iosystem => io_system
+#endif
       else
 !call mpas_log_write('MGD PIO_init')
          if ( io_task_count < 0 .or. io_task_count > ioContext % dminfo % nprocs ) then
@@ -142,6 +190,7 @@ module mpas_io
             call mpas_log_write('Invalid PIO configuration.', MPAS_LOG_CRIT)
          end if
 
+#ifdef MPAS_PIO_SUPPORT
          allocate(ioContext % pio_iosystem)
          call PIO_init(ioContext % dminfo % my_proc_id, &  ! comp_rank
                        ioContext % dminfo % comm,       &  ! comp_comm
@@ -150,10 +199,29 @@ module mpas_io
                        io_task_stride,            &     ! stride
                        PIO_rearr_box,             &     ! rearr
                        ioContext % pio_iosystem)           ! iosystem
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+         allocate(ioContext % smiol_context)
+         local_ierr = SMIOLf_init(ioContext % dminfo % comm, &
+                                  io_task_count, &
+                                  io_task_stride, &
+                                  iocontext % smiol_context)
+         if (local_ierr /= SMIOL_SUCCESS) then
+            call mpas_log_write('SMIOLf_init failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+            if (local_ierr == SMIOL_LIBRARY_ERROR) then
+               call mpas_log_write(trim(SMIOLf_lib_error_string(ioContext % smiol_context)), messageType=MPAS_LOG_CRIT)
+            else
+               call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_CRIT)
+            end if
+         end if
+#endif
   
       end if
 
+#ifdef MPAS_PIO_SUPPORT
       call pio_seterrorhandling(ioContext % pio_iosystem, PIO_BCAST_ERROR)
+#endif
 
    end subroutine MPAS_io_init
 
@@ -225,12 +293,20 @@ module mpas_io
       type (mpas_io_context_type), pointer :: ioContext
       logical, intent(in), optional :: clobber_file
       logical, intent(in), optional :: truncate_file
+#ifdef MPAS_PIO_SUPPORT
       type (file_desc_t), intent(inout), optional :: pio_file_desc
+#else
+      integer, optional :: pio_file_desc
+#endif
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr, pio_iotype, pio_mode
+      integer :: local_ierr
       logical :: local_clobber, local_truncate
       logical :: exists
+#ifdef MPAS_SMIOL_SUPPORT
+      integer(kind=SMIOL_offset_kind) :: preexisting_records
+#endif
 
 !      call mpas_log_write('Called MPAS_io_open()')
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -270,6 +346,7 @@ module mpas_io
       MPAS_io_open % ioformat = ioformat
       MPAS_io_open % ioContext => ioContext
 
+#ifdef MPAS_PIO_SUPPORT
       if (ioContext % master_pio_iotype /= -999) then
          pio_iotype = ioContext % master_pio_iotype
          pio_mode = PIO_64BIT_OFFSET
@@ -292,9 +369,12 @@ module mpas_io
 #endif
          end if
       end if
+#endif
 
       if (present(pio_file_desc)) then
+#ifdef MPAS_PIO_SUPPORT
          MPAS_io_open % pio_file = pio_file_desc
+#endif
          MPAS_io_open % external_file_desc = .true.
       else
          if (mode == MPAS_IO_WRITE) then
@@ -312,10 +392,22 @@ module mpas_io
             end if
  
             if (exists .and. (.not. local_truncate)) then
+#ifdef MPAS_PIO_SUPPORT
                pio_ierr = PIO_openfile(ioContext % pio_iosystem, MPAS_io_open % pio_file, pio_iotype, trim(filename), PIO_write)
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_open_file(ioContext % smiol_context, trim(filename), &
+                                             SMIOL_FILE_WRITE, MPAS_io_open % smiol_file)
+#endif
                MPAS_io_open % preexisting_file = .true.
             else
+#ifdef MPAS_PIO_SUPPORT
                pio_ierr = PIO_createfile(ioContext % pio_iosystem, MPAS_io_open % pio_file, pio_iotype, trim(filename), pio_mode)
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_open_file(ioContext % smiol_context, trim(filename), &
+                                             SMIOL_FILE_CREATE, MPAS_io_open % smiol_file)
+#endif
 #ifdef MPAS_DEBUG
                if (exists) then
                   call mpas_log_write('MPAS I/O: Truncating existing data in output file '//trim(filename), MPAS_LOG_WARN)
@@ -329,27 +421,52 @@ module mpas_io
                if (present(ierr)) ierr = MPAS_IO_ERR_NOEXIST_READ
                return
             end if
+#ifdef MPAS_PIO_SUPPORT
 !call mpas_log_write('MGD PIO_openfile')
             pio_ierr = PIO_openfile(ioContext % pio_iosystem, MPAS_io_open % pio_file, pio_iotype, trim(filename), PIO_nowrite)
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_open_file(ioContext % smiol_context, trim(filename), &
+                                          SMIOL_FILE_READ, MPAS_io_open % smiol_file)
+#endif
          endif
+#ifdef MPAS_PIO_SUPPORT
          if (pio_ierr /= PIO_noerr) then
-            pio_global_ierr = pio_ierr
-            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+            io_global_err = pio_ierr
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             return
          end if
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+         if (local_ierr /= SMIOL_SUCCESS) then
+            call mpas_log_write('SMIOLf_open_file failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+            if (local_ierr == SMIOL_LIBRARY_ERROR) then
+               call mpas_log_write(trim(SMIOLf_lib_error_string(ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+            else
+               call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+            end if
+
+            io_global_err = local_ierr
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+            return
+         end if
+#endif
          MPAS_io_open % external_file_desc = .false.
       end if
 
       if (mode == MPAS_IO_READ .or. MPAS_io_open % preexisting_file) then
+#ifdef MPAS_PIO_SUPPORT
 !MPAS_io_open % pio_unlimited_dimid = 44
          pio_ierr = PIO_inquire(MPAS_io_open % pio_file, unlimitedDimID=MPAS_io_open % pio_unlimited_dimid)
 !call mpas_log_write('Found unlimited dim $i', intArgs=(/MPAS_io_open % pio_unlimited_dimid/) )
          if (pio_ierr /= PIO_noerr) then
-            pio_global_ierr = pio_ierr
-            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+            io_global_err = pio_ierr
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             return
          end if
+#endif
 
+#ifdef MPAS_PIO_SUPPORT
          ! Here we're depending on the undocumented behavior of PIO to return a
          ! negative dimension ID when an unlimited dimension is not found.  This
          ! might change in the future, causing this code to break, though it
@@ -357,13 +474,19 @@ module mpas_io
          if ( MPAS_io_open % pio_unlimited_dimid >= 0 ) then
             pio_ierr = PIO_inq_dimlen(MPAS_io_open % pio_file, MPAS_io_open % pio_unlimited_dimid, MPAS_io_open % preexisting_records)
             if (pio_ierr /= PIO_noerr) then
-               pio_global_ierr = pio_ierr
-               if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+               io_global_err = pio_ierr
+               if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
                return
             end if
          else
             MPAS_io_open % preexisting_records = -1
          end if
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+!MGD TODO: need a way to determine which dimension is the unlimited dimension
+         local_ierr = SMIOLf_inquire_dim(MPAS_io_open % smiol_file, 'Time', dimsize=preexisting_records)
+         MPAS_io_open % preexisting_records = preexisting_records
+#endif
       end if
 
       MPAS_io_open % initialized = .true.
@@ -396,13 +519,19 @@ module mpas_io
          return
       end if
 
+#ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_dimname(handle % pio_file, handle % pio_unlimited_dimid, dimname) 
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_NO_UNLIMITED_DIM
          dimname = ' '
          return
       end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+!MGD TODO: Do this for SMIOL once we have a way to inquire about unlimited dim by name
+      dimname = 'Time'
+#endif
 
    end subroutine MPAS_io_inq_unlimited_dim
 
@@ -419,6 +548,10 @@ module mpas_io
       type (dimlist_type), pointer :: new_dimlist_node
       type (dimlist_type), pointer :: dim_cursor
       integer :: pio_ierr
+      integer :: local_ierr
+#ifdef MPAS_SMIOL_SUPPORT
+      integer(kind=SMIOL_offset_kind) :: local_dimsize
+#endif
 
 !      call mpas_log_write('Called MPAS_io_inq_dim()')
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -452,9 +585,9 @@ module mpas_io
 
       new_dimlist_node % dimhandle % dimname = dimname
 
+#ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_dimid(handle % pio_file, trim(dimname), new_dimlist_node % dimhandle % dimid)
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
          if (present(ierr)) ierr = MPAS_IO_ERR_MISSING_DIM
          deallocate(new_dimlist_node % dimhandle)
          deallocate(new_dimlist_node)
@@ -466,13 +599,28 @@ module mpas_io
 
       pio_ierr = PIO_inq_dimlen(handle % pio_file, new_dimlist_node % dimhandle % dimid, new_dimlist_node % dimhandle % dimsize)
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          deallocate(new_dimlist_node % dimhandle)
          deallocate(new_dimlist_node)
          dimsize = -1
          return
       end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+      local_ierr = SMIOLf_inquire_dim(handle % smiol_file, trim(dimname), &
+                                      dimsize=local_dimsize, &
+                                      is_unlimited=new_dimlist_node % dimhandle % is_unlimited_dim)
+      if (local_ierr /= SMIOL_SUCCESS) then
+         if (present(ierr)) ierr = MPAS_IO_ERR_MISSING_DIM
+         deallocate(new_dimlist_node % dimhandle)
+         deallocate(new_dimlist_node)
+         dimsize = -1
+         return
+      end if
+      new_dimlist_node % dimhandle % dimsize = local_dimsize
+#endif
    
       ! Keep dimension information for future reference
       if (.not. associated(handle % dimlist_head)) then
@@ -500,7 +648,11 @@ module mpas_io
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
+      integer :: local_ierr
       integer :: inq_dimsize
+#ifdef MPAS_SMIOL_SUPPORT
+      integer(kind=SMIOL_offset_kind) :: local_dimsize
+#endif
       type (dimlist_type), pointer :: new_dimlist_node
       type (dimlist_type), pointer :: dim_cursor
 
@@ -555,7 +707,7 @@ module mpas_io
       !
       if (handle % preexisting_file) then
          call MPAS_io_inq_dim(handle, dimname, inq_dimsize, ierr=pio_ierr)
-         if (pio_ierr /= MPAS_IO_ERR_PIO) then
+         if (pio_ierr /= MPAS_IO_ERR_BACKEND) then
 
             ! Verify that the dimsize matches...
             if (dimsize /= inq_dimsize .and. dimsize /= MPAS_IO_UNLIMITED_DIM) then
@@ -579,17 +731,44 @@ module mpas_io
       new_dimlist_node % dimhandle % dimsize = dimsize
       if (dimsize == MPAS_IO_UNLIMITED_DIM) then
          new_dimlist_node % dimhandle % is_unlimited_dim = .true.
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_def_dim(handle % pio_file, trim(dimname), PIO_unlimited, new_dimlist_node % dimhandle % dimid)
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+         local_dimsize = -1_SMIOL_offset_kind
+#endif
       else
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_def_dim(handle % pio_file, trim(dimname), dimsize, new_dimlist_node % dimhandle % dimid)
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+         local_dimsize = int(dimsize,kind=SMIOL_offset_kind)
+#endif
       end if
+#ifdef MPAS_SMIOL_SUPPORT
+      local_ierr = SMIOLf_define_dim(handle % smiol_file, trim(dimname), local_dimsize)
+      if (local_ierr /= SMIOL_SUCCESS) then
+         call mpas_log_write('SMIOLf_define_dim failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         if (local_ierr == SMIOL_LIBRARY_ERROR) then
+            call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+         else
+            call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+         end if
+
+         io_global_err = local_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+         return
+      end if
+#endif
+#ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          deallocate(new_dimlist_node % dimhandle)
          deallocate(new_dimlist_node)
          return
       end if
+#endif
 
       ! Keep dimension information
       if (.not. associated(handle % dimlist_head)) then
@@ -628,6 +807,13 @@ module mpas_io
       integer, dimension(:), pointer :: dimids
       logical :: found
       integer :: pio_ierr
+      integer :: local_ierr
+      integer :: smiol_type
+      integer :: smiol_ndims
+      character(len=StrKind), dimension(:), allocatable :: smiol_dimnames
+#ifdef MPAS_SMIOL_SUPPORT
+      integer(kind=SMIOL_offset_kind) :: smiol_dimlen
+#endif
 
 
 !      call mpas_log_write('Called MPAS_io_inq_var()')
@@ -666,11 +852,12 @@ module mpas_io
          new_fieldlist_node % fieldhandle % fieldname = fieldname
 
          ! Get variable ID
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_inq_varid(handle % pio_file, trim(fieldname), new_fieldlist_node % fieldhandle % fieldid)
          pio_ierr = PIO_inq_varid(handle % pio_file, trim(fieldname), new_fieldlist_node % fieldhandle % field_desc)
          if (pio_ierr /= PIO_noerr) then
-            pio_global_ierr = pio_ierr
-            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+            io_global_err = pio_ierr
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             deallocate(new_fieldlist_node % fieldhandle)
             deallocate(new_fieldlist_node)
             call mpas_log_write('Variable ' // trim(fieldname) // ' not in input file.', MPAS_LOG_WARN)
@@ -681,8 +868,8 @@ module mpas_io
          ! Get field type
          pio_ierr = PIO_inq_vartype(handle % pio_file, new_fieldlist_node % fieldhandle % fieldid, new_fieldlist_node % fieldhandle % field_type)
          if (pio_ierr /= PIO_noerr) then
-            pio_global_ierr = pio_ierr
-            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+            io_global_err = pio_ierr
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             deallocate(new_fieldlist_node % fieldhandle)
             deallocate(new_fieldlist_node)
             return
@@ -703,26 +890,78 @@ module mpas_io
             new_fieldlist_node % fieldhandle % field_type = MPAS_IO_CHAR
 !!!!!!!! PIO DOES NOT SUPPORT LOGICAL !!!!!!!!
          end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+         local_ierr = SMIOLf_inquire_var(handle % smiol_file, trim(fieldname), vartype=smiol_type)
+         if (local_ierr /= SMIOL_SUCCESS) then
+            io_global_err = local_ierr
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+            deallocate(new_fieldlist_node % fieldhandle)
+            deallocate(new_fieldlist_node)
+            call mpas_log_write('Variable ' // trim(fieldname) // ' not in input file.', MPAS_LOG_WARN)
+            return
+         end if
+         new_fieldlist_node % fieldhandle % field_type = smiol_type
+
+         ! Convert to MPAS type
+         new_fieldlist_node % fieldhandle % precision = MPAS_IO_NATIVE_PRECISION
+         if (new_fieldlist_node % fieldhandle % field_type == SMIOL_REAL64) then
+            new_fieldlist_node % fieldhandle % field_type = MPAS_IO_DOUBLE
+            new_fieldlist_node % fieldhandle % precision = MPAS_IO_DOUBLE_PRECISION
+         else if (new_fieldlist_node % fieldhandle % field_type == SMIOL_REAL32) then
+            new_fieldlist_node % fieldhandle % field_type = MPAS_IO_REAL
+            new_fieldlist_node % fieldhandle % precision = MPAS_IO_SINGLE_PRECISION
+         else if (new_fieldlist_node % fieldhandle % field_type == SMIOL_INT32) then
+            new_fieldlist_node % fieldhandle % field_type = MPAS_IO_INT
+         else if (new_fieldlist_node % fieldhandle % field_type == SMIOL_CHAR) then
+            new_fieldlist_node % fieldhandle % field_type = MPAS_IO_CHAR
+         end if
+#endif
 
          ! Get number of dimensions
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_inq_varndims(handle % pio_file, new_fieldlist_node % fieldhandle % fieldid, new_fieldlist_node % fieldhandle % ndims)
          if (pio_ierr /= PIO_noerr) then
-            pio_global_ierr = pio_ierr
-            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+            io_global_err = pio_ierr
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             deallocate(new_fieldlist_node % fieldhandle)
             deallocate(new_fieldlist_node)
             return
          end if
 !call mpas_log_write('Inquired about number of dimensions $i', intArgs=(/new_fieldlist_node % fieldhandle % ndims/) )
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+         local_ierr = SMIOLf_inquire_var(handle % smiol_file, trim(fieldname), ndims=smiol_ndims)
+         if (local_ierr /= SMIOL_SUCCESS) then
+            call mpas_log_write('SMIOLf_inquire_var failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+            if (local_ierr == SMIOL_LIBRARY_ERROR) then
+               call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+            else
+               call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+            end if
+
+            io_global_err = local_ierr
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+
+            deallocate(new_fieldlist_node % fieldhandle)
+            deallocate(new_fieldlist_node)
+            call mpas_log_write('Variable ' // trim(fieldname) // ' not in input file.', MPAS_LOG_WARN)
+            return
+         end if
+         new_fieldlist_node% fieldhandle % ndims = smiol_ndims
+#endif
 
          allocate(dimids(new_fieldlist_node % fieldhandle % ndims))
 
          ! Get dimension IDs
+#ifdef MPAS_PIO_SUPPORT
          if (new_fieldlist_node % fieldhandle % ndims > 0) then
             pio_ierr = PIO_inq_vardimid(handle % pio_file, new_fieldlist_node % fieldhandle % fieldid, dimids)
             if (pio_ierr /= PIO_noerr) then
-               pio_global_ierr = pio_ierr
-               if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+               io_global_err = pio_ierr
+               if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
                deallocate(new_fieldlist_node % fieldhandle)
                deallocate(new_fieldlist_node)
                deallocate(dimids)
@@ -730,9 +969,11 @@ module mpas_io
             end if
 !call mpas_log_write('Inquired about dimension IDs $i.', intArgs=(/dimids/) )
          end if
+#endif
 
          allocate(new_fieldlist_node % fieldhandle % dims(new_fieldlist_node % fieldhandle % ndims))
 
+#ifdef MPAS_PIO_SUPPORT
          ! Get information about dimensions
          do i=1,new_fieldlist_node % fieldhandle % ndims
             new_fieldlist_node % fieldhandle % dims(i) % dimid = dimids(i)
@@ -743,8 +984,8 @@ module mpas_io
 
             pio_ierr = PIO_inq_dimlen(handle % pio_file, dimids(i), new_fieldlist_node % fieldhandle % dims(i) % dimsize)
             if (pio_ierr /= PIO_noerr) then
-               pio_global_ierr = pio_ierr
-               if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+               io_global_err = pio_ierr
+               if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
                deallocate(new_fieldlist_node % fieldhandle)
                deallocate(new_fieldlist_node)
                deallocate(dimids)
@@ -754,8 +995,8 @@ module mpas_io
 
             pio_ierr = PIO_inq_dimname(handle % pio_file, dimids(i), new_fieldlist_node % fieldhandle % dims(i) % dimname)
             if (pio_ierr /= PIO_noerr) then
-               pio_global_ierr = pio_ierr
-               if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+               io_global_err = pio_ierr
+               if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
                deallocate(new_fieldlist_node % fieldhandle)
                deallocate(new_fieldlist_node)
                deallocate(dimids)
@@ -764,6 +1005,50 @@ module mpas_io
 !call mpas_log_write('Inquired about dimension name ' // trim(new_fieldlist_node % fieldhandle % dims(i) % dimname))
 
          end do
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+         new_fieldlist_node % fieldhandle % has_unlimited_dim = .false.
+         allocate(smiol_dimnames(smiol_ndims))
+         local_ierr = SMIOLf_inquire_var(handle % smiol_file, trim(fieldname), dimnames=smiol_dimnames)
+         if (local_ierr /= SMIOL_SUCCESS) then
+            call mpas_log_write('SMIOLf_inquire_var failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+            if (local_ierr == SMIOL_LIBRARY_ERROR) then
+               call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+            else
+               call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+            end if
+
+            io_global_err = local_ierr
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+            return
+         end if
+         do i=1,new_fieldlist_node % fieldhandle % ndims
+            new_fieldlist_node % fieldhandle % dims(i) % dimname = smiol_dimnames(i)
+         end do
+         do i=1,new_fieldlist_node % fieldhandle % ndims
+            local_ierr = SMIOLf_inquire_dim(handle % smiol_file, trim(smiol_dimnames(i)), &
+                                            dimsize=smiol_dimlen, &
+                                            is_unlimited=new_fieldlist_node % fieldhandle % dims(i) % is_unlimited_dim)
+            if (local_ierr /= SMIOL_SUCCESS) then
+               call mpas_log_write('SMIOLf_inquire_dim failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+               if (local_ierr == SMIOL_LIBRARY_ERROR) then
+                  call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+               else
+                  call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+               end if
+
+               io_global_err = local_ierr
+               if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+               return
+            end if
+            new_fieldlist_node % fieldhandle % dims(i) % dimsize = smiol_dimlen
+            if (new_fieldlist_node % fieldhandle % dims(i) % is_unlimited_dim) then
+               new_fieldlist_node % fieldhandle % has_unlimited_dim = .true.
+            end if
+         end do
+         deallocate(smiol_dimnames)
+#endif
 
          deallocate(dimids)
 
@@ -851,7 +1136,9 @@ module mpas_io
 
       integer :: i
       integer :: pio_ierr
+      integer :: local_ierr
       integer :: pio_type
+      integer :: smiol_type
       integer :: ndims
       integer :: inq_fieldtype
       integer :: inq_ndims
@@ -922,7 +1209,7 @@ module mpas_io
       !
       if (handle % preexisting_file) then
          call MPAS_io_inq_var(handle, fieldname, inq_fieldtype, inq_ndims, inq_dimnames, ierr=pio_ierr)
-         if (pio_ierr /= MPAS_IO_ERR_PIO) then
+         if (pio_ierr /= MPAS_IO_ERR_BACKEND) then
 
             ! Verify that the type and dimensions match...
             if (fieldtype == MPAS_IO_DOUBLE) then
@@ -1003,43 +1290,92 @@ module mpas_io
       ! Convert from MPAS type
       if (new_fieldlist_node % fieldhandle % field_type == MPAS_IO_DOUBLE) then
          if (local_precision == MPAS_IO_SINGLE_PRECISION) then
+#ifdef MPAS_PIO_SUPPORT
             pio_type = PIO_real
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+            smiol_type = SMIOL_REAL32
+#endif
             new_fieldlist_node % fieldhandle % field_type = MPAS_IO_REAL
          else
+#ifdef MPAS_PIO_SUPPORT
             pio_type = PIO_double
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+            smiol_type = SMIOL_REAL64
+#endif
          end if
       else if (new_fieldlist_node % fieldhandle % field_type == MPAS_IO_REAL) then
          if (local_precision == MPAS_IO_DOUBLE_PRECISION) then
+#ifdef MPAS_PIO_SUPPORT
             pio_type = PIO_double
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+            smiol_type = SMIOL_REAL64
+#endif
             new_fieldlist_node % fieldhandle % field_type = MPAS_IO_DOUBLE
          else
+#ifdef MPAS_PIO_SUPPORT
             pio_type = PIO_real
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+            smiol_type = SMIOL_REAL32
+#endif
          end if
       else if (new_fieldlist_node % fieldhandle % field_type == MPAS_IO_INT) then
+#ifdef MPAS_PIO_SUPPORT
          pio_type = PIO_int
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+         smiol_type = SMIOL_INT32
+#endif
       else if (new_fieldlist_node % fieldhandle % field_type == MPAS_IO_CHAR) then
+#ifdef MPAS_PIO_SUPPORT
          pio_type = PIO_char
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+         smiol_type = SMIOL_CHAR
+#endif
 !!!!!!!! PIO DOES NOT SUPPORT LOGICAL !!!!!!!!
       end if
 
+#ifdef MPAS_PIO_SUPPORT
       if (ndims == 0) then
          pio_ierr = PIO_def_var(handle % pio_file, trim(fieldname), pio_type, new_fieldlist_node % fieldhandle % field_desc)
       else
          pio_ierr = PIO_def_var(handle % pio_file, trim(fieldname), pio_type, dimids, new_fieldlist_node % fieldhandle % field_desc)
       end if
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+      local_ierr = SMIOLf_define_var(handle % smiol_file, trim(fieldname), smiol_type, size(dimnames), dimnames)
+      if (local_ierr /= SMIOL_SUCCESS) then
+         call mpas_log_write('SMIOLf_define_var failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         if (local_ierr == SMIOL_LIBRARY_ERROR) then
+            call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+         else
+            call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+         end if
+
+         io_global_err = local_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+         return
+      end if
+#endif
 
       ! Get the varid for use by put_att routines
+#ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_varid(handle % pio_file, trim(fieldname), new_fieldlist_node % fieldhandle % fieldid)
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
+#endif
 
       deallocate(dimids)
 
@@ -1127,6 +1463,11 @@ module mpas_io
       integer, dimension(:), pointer :: dimlist
       integer (kind=MPAS_IO_OFFSET_KIND), dimension(:), pointer :: compdof
       type (decomplist_type), pointer :: decomp_cursor, new_decomp
+#ifdef MPAS_SMIOL_SUPPORT
+      integer(kind=SMIOL_offset_kind), dimension(:), pointer :: smiol_indices
+      integer :: local_ierr
+      integer(kind=SMIOL_offset_kind) :: smiol_n_compute_elements
+#endif
 
 !      call mpas_log_write('Called MPAS_io_set_var_indices()')
       if (present(ierr)) ierr = MPAS_IO_NOERR
@@ -1172,6 +1513,7 @@ module mpas_io
 !if (.not. associated(decomp_cursor)) call mpas_log_write('No existing decompositions to check...')
       early_return = 0
       DECOMP_LOOP: do while (associated(decomp_cursor))
+#ifdef MPAS_PIO_SUPPORT
          if (decomp_cursor % decomphandle % field_type == field_cursor % fieldhandle % field_type) then
          if (size(decomp_cursor % decomphandle % dims) == field_cursor % fieldhandle % ndims) then
 !call mpas_log_write('Number of dimensions matches...')
@@ -1182,6 +1524,7 @@ module mpas_io
                   cycle DECOMP_LOOP
                end if
             end do
+#endif
 
             if (size(decomp_cursor % decomphandle % indices) /= size(indices)) then
 !call mpas_log_write('We do not have the same number of indices in this decomposition...')
@@ -1202,6 +1545,7 @@ module mpas_io
 !call mpas_log_write('Found a matching decomposition that we can use')
             early_return = 1
             exit DECOMP_LOOP
+#ifdef MPAS_PIO_SUPPORT
          else if ((size(decomp_cursor % decomphandle % dims) == field_cursor % fieldhandle % ndims - 1)  &
                   .and. field_cursor % fieldhandle % has_unlimited_dim  &
                  ) then
@@ -1237,6 +1581,7 @@ module mpas_io
             exit DECOMP_LOOP
          end if
          end if
+#endif
          decomp_cursor => decomp_cursor % next
       end do DECOMP_LOOP
 
@@ -1269,6 +1614,7 @@ module mpas_io
       new_decomp % decomphandle % indices(:) = indices(:)
 
       ! Convert from MPAS type
+#ifdef MPAS_PIO_SUPPORT
       if (field_cursor % fieldhandle % field_type == MPAS_IO_DOUBLE) then
          pio_type = PIO_double
       else if (field_cursor % fieldhandle % field_type == MPAS_IO_REAL) then
@@ -1351,6 +1697,30 @@ module mpas_io
 
       dimlist(ndims) = field_cursor % fieldhandle % dims(ndims) % dimsize
       call PIO_initdecomp(handle % ioContext % pio_iosystem, pio_type, dimlist, compdof, new_decomp % decomphandle % pio_iodesc)
+      deallocate(compdof)
+      deallocate(dimlist)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+      allocate(smiol_indices(size(indices)))
+      smiol_indices(:) = int(indices(:), kind=SMIOL_offset_kind) - 1_SMIOL_offset_kind   ! SMIOL indices are 0-based
+      smiol_n_compute_elements = size(indices,kind=SMIOL_offset_kind)
+      local_ierr = SMIOLf_create_decomp(handle % ioContext % smiol_context, smiol_n_compute_elements, smiol_indices, &
+                                        new_decomp % decomphandle % smiol_decomp)
+      deallocate(smiol_indices)
+      if (local_ierr /= SMIOL_SUCCESS) then
+         call mpas_log_write('SMIOLf_create_decomp failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         if (local_ierr == SMIOL_LIBRARY_ERROR) then
+            call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+         else
+            call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+         end if
+
+         io_global_err = local_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+         return
+      end if
+#endif
 
       ! Add new decomposition to the list
       if (.not. associated(handle % ioContext % decomp_list)) then
@@ -1365,8 +1735,6 @@ module mpas_io
 !call mpas_log_write('Setting decomp in fieldhandle')
       field_cursor % fieldhandle % decomp => new_decomp % decomphandle
 
-      deallocate(compdof)
-      deallocate(dimlist)
 !call mpas_log_write('All finished.')
 
    end subroutine MPAS_io_set_var_indices
@@ -1380,22 +1748,23 @@ module mpas_io
 
       type (MPAS_IO_Handle_type), intent(inout) :: handle
       character (len=*), intent(in) :: fieldname
-      integer, intent(out), optional :: intVal
-      integer, dimension(:), intent(out), optional :: intArray1d
-      integer, dimension(:,:), intent(out), optional :: intArray2d
-      integer, dimension(:,:,:), intent(out), optional :: intArray3d
-      integer, dimension(:,:,:,:), intent(out), optional :: intArray4d
-      real (kind=RKIND), intent(out), optional :: realVal
-      real (kind=RKIND), dimension(:), intent(out), optional :: realArray1d
-      real (kind=RKIND), dimension(:,:), intent(out), optional :: realArray2d
-      real (kind=RKIND), dimension(:,:,:), intent(out), optional :: realArray3d
-      real (kind=RKIND), dimension(:,:,:,:), intent(out), optional :: realArray4d
-      real (kind=RKIND), dimension(:,:,:,:,:), intent(out), optional :: realArray5d
-      character (len=*), intent(out), optional :: charVal
-      character (len=*), dimension(:), intent(out), optional :: charArray1d
+      integer, intent(out), target, optional :: intVal
+      integer, dimension(:), intent(out), target, optional :: intArray1d
+      integer, dimension(:,:), intent(out), target, optional :: intArray2d
+      integer, dimension(:,:,:), intent(out), target, optional :: intArray3d
+      integer, dimension(:,:,:,:), intent(out), target, optional :: intArray4d
+      real (kind=RKIND), intent(out), target, optional :: realVal
+      real (kind=RKIND), dimension(:), intent(out), target, optional :: realArray1d
+      real (kind=RKIND), dimension(:,:), intent(out), target, optional :: realArray2d
+      real (kind=RKIND), dimension(:,:,:), intent(out), target, optional :: realArray3d
+      real (kind=RKIND), dimension(:,:,:,:), intent(out), target, optional :: realArray4d
+      real (kind=RKIND), dimension(:,:,:,:,:), intent(out), target, optional :: realArray5d
+      character (len=*), intent(out), target, optional :: charVal
+      character (len=*), dimension(:), intent(out), target, optional :: charArray1d
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
+      integer :: local_ierr
       integer, dimension(1) :: start1
       integer, dimension(1) :: count1
       integer, dimension(2) :: start2
@@ -1413,19 +1782,44 @@ module mpas_io
 
       integer i, j
 
-      real (kind=R4KIND) :: singleVal
-      real (kind=R4KIND), dimension(:), allocatable :: singleArray1d
-      real (kind=R4KIND), dimension(:,:), allocatable :: singleArray2d
-      real (kind=R4KIND), dimension(:,:,:), allocatable :: singleArray3d
-      real (kind=R4KIND), dimension(:,:,:,:), allocatable :: singleArray4d
-      real (kind=R4KIND), dimension(:,:,:,:,:), allocatable :: singleArray5d
+      real (kind=R4KIND), pointer :: singleVal
+      real (kind=R4KIND), target :: singleVal_target
+      real (kind=R4KIND), dimension(:), pointer :: singleArray1d
+      real (kind=R4KIND), dimension(:,:), pointer :: singleArray2d
+      real (kind=R4KIND), dimension(:,:,:), pointer :: singleArray3d
+      real (kind=R4KIND), dimension(:,:,:,:), pointer :: singleArray4d
+      real (kind=R4KIND), dimension(:,:,:,:,:), pointer :: singleArray5d
 
-      real (kind=R8KIND) :: doubleVal
-      real (kind=R8KIND), dimension(:), allocatable :: doubleArray1d
-      real (kind=R8KIND), dimension(:,:), allocatable :: doubleArray2d
-      real (kind=R8KIND), dimension(:,:,:), allocatable :: doubleArray3d
-      real (kind=R8KIND), dimension(:,:,:,:), allocatable :: doubleArray4d
-      real (kind=R8KIND), dimension(:,:,:,:,:), allocatable :: doubleArray5d
+      real (kind=R8KIND), pointer :: doubleVal
+      real (kind=R8KIND), target :: doubleVal_target
+      real (kind=R8KIND), dimension(:), pointer :: doubleArray1d
+      real (kind=R8KIND), dimension(:,:), pointer :: doubleArray2d
+      real (kind=R8KIND), dimension(:,:,:), pointer :: doubleArray3d
+      real (kind=R8KIND), dimension(:,:,:,:), pointer :: doubleArray4d
+      real (kind=R8KIND), dimension(:,:,:,:,:), pointer :: doubleArray5d
+
+      integer, pointer :: intVal_p
+      integer, dimension(:), pointer :: intArray1d_p
+      integer, dimension(:,:), pointer :: intArray2d_p
+      integer, dimension(:,:,:), pointer :: intArray3d_p
+      integer, dimension(:,:,:,:), pointer :: intArray4d_p
+      real (kind=RKIND), pointer :: realVal_p
+      real (kind=RKIND), dimension(:), pointer :: realArray1d_p
+      real (kind=RKIND), dimension(:,:), pointer :: realArray2d_p
+      real (kind=RKIND), dimension(:,:,:), pointer :: realArray3d_p
+      real (kind=RKIND), dimension(:,:,:,:), pointer :: realArray4d_p
+      real (kind=RKIND), dimension(:,:,:,:,:), pointer :: realArray5d_p
+      character (len=:), pointer :: charVal_p
+      character (len=:), dimension(:), pointer :: charArray1d_p
+
+#ifdef MPAS_SMIOL_SUPPORT
+      type (SMIOLf_decomp), pointer :: null_decomp
+
+      nullify(null_decomp)
+#endif
+
+      singleVal => singleVal_target
+      doubleVal => doubleVal_target
 
       ! Sanity checks
       if (.not. handle % initialized) then
@@ -1455,11 +1849,30 @@ module mpas_io
 
 !      call mpas_log_write('Checking for unlimited dim')
       if (field_cursor % fieldhandle % has_unlimited_dim) then
+#ifdef MPAS_PIO_SUPPORT
 #ifdef USE_PIO2
          call PIO_setframe(handle % pio_file, field_cursor % fieldhandle % field_desc, handle % frame_number)
 #else
          call PIO_setframe(field_cursor % fieldhandle % field_desc, handle % frame_number)
 #endif
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+         local_ierr = SMIOLf_set_frame(handle % smiol_file, int(handle % frame_number - 1, kind=SMIOL_offset_kind))
+         if (local_ierr /= SMIOL_SUCCESS) then
+            call mpas_log_write('SMIOLf_set_frame failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+            if (local_ierr == SMIOL_LIBRARY_ERROR) then
+               call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+            else
+               call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+            end if
+
+            io_global_err = local_ierr
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+            return
+         end if
+#endif
+
          start1(1) = handle % frame_number
          count1(1) = 1
      
@@ -1473,36 +1886,74 @@ module mpas_io
 !         call mpas_log_write('  value is real')
          if ((field_cursor % fieldhandle % precision == MPAS_IO_SINGLE_PRECISION) .and. &
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, singleVal)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, singleVal)
             else
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % field_desc, singleVal)
             end if
+#endif
+
             realVal = real(singleVal,RKIND)
          else if ((field_cursor % fieldhandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, doubleVal)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, doubleVal)
             else
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % field_desc, doubleVal)
             end if
+#endif
+
             realVal = real(doubleVal,RKIND)
          else
+            realVal_p => realVal
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, realVal_p)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, realVal)
             else
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % field_desc, realVal)
             end if
+#endif
          end if
       else if (present(intVal)) then
 !         call mpas_log_write('  value is int')
+
+         intVal_p => intVal
+#ifdef MPAS_SMIOL_SUPPORT
+         local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, intVal_p)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
          if (field_cursor % fieldhandle % has_unlimited_dim) then
             pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, intVal)
          else
             pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % field_desc, intVal)
          end if
+#endif
       else if (present(charVal)) then
 !         call mpas_log_write('  value is char')
+
+         charVal_p => charVal
+#ifdef MPAS_SMIOL_SUPPORT
+         local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, charVal_p)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
          if (field_cursor % fieldhandle % has_unlimited_dim) then
             count2(1) = field_cursor % fieldhandle % dims(1) % dimsize
             pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start2, count2, tempchar)
@@ -1513,8 +1964,10 @@ module mpas_io
             pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start1, count1, tempchar)
             charVal(1:count1(1)) = tempchar(1)(1:count1(1))
          end if
+#endif
       else if (present(charArray1d)) then
 !         call mpas_log_write('  value is char1')
+#ifdef MPAS_PIO_SUPPORT
          if (field_cursor % fieldhandle % has_unlimited_dim) then
             ! Can only read one string at a time, since the sizes differ so much (i.e. StrLen != StrKIND)
             do i = 1, field_cursor % fieldhandle % dims(2) % dimsize
@@ -1558,15 +2011,33 @@ module mpas_io
                end do
             end do
          end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+         call mpas_log_write('1-d char variables not yet implemented in SMIOL: '//trim(fieldname), messageType=MPAS_LOG_ERR)
+#endif
+
       else if (present(realArray1d)) then
 !         call mpas_log_write('  value is real1')
          if ((field_cursor % fieldhandle % precision == MPAS_IO_SINGLE_PRECISION) .and. &
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
             allocate(singleArray1d(size(realArray1d,1)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, singleArray1d)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     singleArray1d, pio_ierr)
+#endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, singleArray1d)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start2(1) = 1
                   start2(2) = handle % frame_number
@@ -1578,6 +2049,7 @@ module mpas_io
                   count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start1, count1, singleArray1d)
                end if
+#endif
             end if
             realArray1d(:) = real(singleArray1d(:),RKIND)
             deallocate(singleArray1d)
@@ -1585,9 +2057,21 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
             allocate(doubleArray1d(size(realArray1d,1)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, doubleArray1d)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     doubleArray1d, pio_ierr)
+#endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, doubleArray1d)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start2(1) = 1
                   start2(2) = handle % frame_number
@@ -1599,14 +2083,28 @@ module mpas_io
                   count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start1, count1, doubleArray1d)
                end if
+#endif
             end if
             realArray1d(:) = real(doubleArray1d(:),RKIND)
             deallocate(doubleArray1d)
          else
+            realArray1d_p => realArray1d
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, realArray1d_p)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     realArray1d, pio_ierr)
+#endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, realArray1d_p)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start2(1) = 1
                   start2(2) = handle % frame_number
@@ -1618,6 +2116,7 @@ module mpas_io
                   count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start1, count1, realArray1d)
                end if
+#endif
             end if
          end if
       else if (present(realArray2d)) then
@@ -1626,9 +2125,21 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
             allocate(singleArray2d(size(realArray2d,1), size(realArray2d,2)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, singleArray2d)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     singleArray2d, pio_ierr)
+#endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, singleArray2d)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start3(:) = 1
                   start3(3) = handle % frame_number
@@ -1642,6 +2153,7 @@ module mpas_io
                   count2(2) = field_cursor % fieldhandle % dims(2) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start2, count2, singleArray2d)
                end if
+#endif
             end if
             realArray2d(:,:) = real(singleArray2d(:,:),RKIND)
             deallocate(singleArray2d)
@@ -1649,9 +2161,21 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
             allocate(doubleArray2d(size(realArray2d,1), size(realArray2d,2)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, doubleArray2d)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     doubleArray2d, pio_ierr)
+#endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, doubleArray2d)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start3(:) = 1
                   start3(3) = handle % frame_number
@@ -1665,14 +2189,28 @@ module mpas_io
                   count2(2) = field_cursor % fieldhandle % dims(2) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start2, count2, doubleArray2d)
                end if
+#endif
             end if
             realArray2d(:,:) = real(doubleArray2d(:,:),RKIND)
             deallocate(doubleArray2d)
          else
+            realArray2d_p => realArray2d
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, realArray2d_p)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     realArray2d, pio_ierr)
+#endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, realArray2d_p)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start3(:) = 1
                   start3(3) = handle % frame_number
@@ -1686,6 +2224,7 @@ module mpas_io
                   count2(2) = field_cursor % fieldhandle % dims(2) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start2, count2, realArray2d)
                end if
+#endif
             end if
          end if
       else if (present(realArray3d)) then
@@ -1694,9 +2233,21 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
             allocate(singleArray3d(size(realArray3d,1),size(realArray3d,2),size(realArray3d,3)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, singleArray3d)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     singleArray3d, pio_ierr)
+#endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, singleArray3d)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start4(:) = 1
                   start4(4) = handle % frame_number
@@ -1712,6 +2263,7 @@ module mpas_io
                   count3(3) = field_cursor % fieldhandle % dims(3) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start3, count3, singleArray3d)
                end if
+#endif
             end if
             realArray3d(:,:,:) = real(singleArray3d(:,:,:),RKIND)
             deallocate(singleArray3d)
@@ -1719,9 +2271,21 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
             allocate(doubleArray3d(size(realArray3d,1),size(realArray3d,2),size(realArray3d,3)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, doubleArray3d)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     doubleArray3d, pio_ierr)
+#endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, doubleArray3d)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start4(:) = 1
                   start4(4) = handle % frame_number
@@ -1737,14 +2301,28 @@ module mpas_io
                   count3(3) = field_cursor % fieldhandle % dims(3) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start3, count3, doubleArray3d)
                end if
+#endif
             end if
             realArray3d(:,:,:) = real(doubleArray3d(:,:,:),RKIND)
             deallocate(doubleArray3d)
          else
+            realArray3d_p => realArray3d
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, realArray3d_p)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     realArray3d, pio_ierr)
+#endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, realArray3d_p)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start4(:) = 1
                   start4(4) = handle % frame_number
@@ -1760,6 +2338,7 @@ module mpas_io
                   count3(3) = field_cursor % fieldhandle % dims(3) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start3, count3, realArray3d)
                end if
+#endif
             end if
          end if
       else if (present(realArray4d)) then
@@ -1768,9 +2347,21 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
             allocate(singleArray4d(size(realArray4d,1),size(realArray4d,2),size(realArray4d,3),size(realArray4d,4)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, singleArray4d)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     singleArray4d, pio_ierr)
+#endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, singleArray4d)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start5(:) = 1
                   start5(5) = handle % frame_number
@@ -1788,6 +2379,7 @@ module mpas_io
                   count4(4) = field_cursor % fieldhandle % dims(4) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start4, count4, singleArray4d)
                end if
+#endif
             end if
             realArray4d(:,:,:,:) = real(singleArray4d(:,:,:,:),RKIND)
             deallocate(singleArray4d)
@@ -1795,9 +2387,21 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
             allocate(doubleArray4d(size(realArray4d,1),size(realArray4d,2),size(realArray4d,3),size(realArray4d,4)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, doubleArray4d)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     doubleArray4d, pio_ierr)
+#endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, doubleArray4d)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start5(:) = 1
                   start5(5) = handle % frame_number
@@ -1815,14 +2419,28 @@ module mpas_io
                   count4(4) = field_cursor % fieldhandle % dims(4) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start4, count4, doubleArray4d)
                end if
+#endif
             end if
             realArray4d(:,:,:,:) = real(doubleArray4d(:,:,:,:),RKIND)
             deallocate(doubleArray4d)
          else
+            realArray4d_p => realArray4d
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, realArray4d_p)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                     realArray4d, pio_ierr)
+#endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, realArray4d_p)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start5(:) = 1
                   start5(5) = handle % frame_number
@@ -1840,6 +2458,7 @@ module mpas_io
                   count4(4) = field_cursor % fieldhandle % dims(4) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start4, count4, realArray4d)
                end if
+#endif
             end if
          end if
       else if (present(realArray5d)) then
@@ -1848,9 +2467,21 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
             allocate(singleArray5d(size(realArray5d,1),size(realArray5d,2),size(realArray5d,3),size(realArray5d,4),size(realArray5d,5)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, singleArray5d)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                    singleArray5d, pio_ierr)
+#endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, singleArray5d)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start6(:) = 1
                   start6(6) = handle % frame_number
@@ -1870,6 +2501,7 @@ module mpas_io
                   count5(5) = field_cursor % fieldhandle % dims(5) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start5, count5, singleArray5d)
                end if
+#endif
             end if
             realArray5d(:,:,:,:,:) = real(singleArray5d(:,:,:,:,:),RKIND)
             deallocate(singleArray5d)
@@ -1877,9 +2509,21 @@ module mpas_io
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
             allocate(doubleArray5d(size(realArray5d,1),size(realArray5d,2),size(realArray5d,3),size(realArray5d,4),size(realArray5d,5)))
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, doubleArray5d)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                    doubleArray5d, pio_ierr)
+#endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, doubleArray5d)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start6(:) = 1
                   start6(6) = handle % frame_number
@@ -1899,14 +2543,28 @@ module mpas_io
                   count5(5) = field_cursor % fieldhandle % dims(5) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start5, count5, doubleArray5d)
                end if
+#endif
             end if
             realArray5d(:,:,:,:,:) = real(doubleArray5d(:,:,:,:,:),RKIND)
             deallocate(doubleArray5d)
          else
+            realArray5d_p => realArray5d
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, realArray5d_p)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                    realArray5d, pio_ierr)
+#endif
             else
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, realArray5d_p)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start6(:) = 1
                   start6(6) = handle % frame_number
@@ -1926,14 +2584,28 @@ module mpas_io
                   count5(5) = field_cursor % fieldhandle % dims(5) % dimsize
                   pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start5, count5, realArray5d)
                end if
+#endif
             end if
          end if
       else if (present(intArray1d)) then
 !         call mpas_log_write('  value is int1')
+         intArray1d_p => intArray1d
          if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, intArray1d_p)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
             call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                  intArray1d, pio_ierr)
+#endif
          else
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, intArray1d_p)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                start2(1) = 1
                start2(2) = handle % frame_number
@@ -1945,13 +2617,27 @@ module mpas_io
                count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start1, count1, intArray1d)
             end if
+#endif
          end if
       else if (present(intArray2d)) then
 !         call mpas_log_write('  value is int2')
+         intArray2d_p => intArray2d
          if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, intArray2d_p)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
             call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                  intArray2d, pio_ierr)
+#endif
          else
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, intArray2d_p)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                start3(:) = 1
                start3(3) = handle % frame_number
@@ -1965,13 +2651,27 @@ module mpas_io
                count2(2) = field_cursor % fieldhandle % dims(2) % dimsize
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start2, count2, intArray2d)
             end if
+#endif
          end if
       else if (present(intArray3d)) then
 !         call mpas_log_write('  value is int3')
+         intArray3d_p => intArray3d
          if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, intArray3d_p)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
             call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                  intArray3d, pio_ierr)
+#endif
          else
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, intArray3d_p)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                start4(:) = 1
                start4(4) = handle % frame_number
@@ -1987,13 +2687,27 @@ module mpas_io
                count3(3) = field_cursor % fieldhandle % dims(3) % dimsize
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start3, count3, intArray3d)
             end if
+#endif
          end if
       else if (present(intArray4d)) then
 !         call mpas_log_write('  value is int4')
+         intArray4d_p => intArray4d
          if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, intArray4d_p)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
             call PIO_read_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                  intArray4d, pio_ierr)
+#endif
          else
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_get_var(handle % smiol_file, trim(fieldname), null_decomp, intArray4d_p)
+#endif
+
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                start5(:) = 1
                start5(5) = handle % frame_number
@@ -2011,15 +2725,33 @@ module mpas_io
                count4(4) = field_cursor % fieldhandle % dims(4) % dimsize
                pio_ierr = PIO_get_var(handle % pio_file, field_cursor % fieldhandle % fieldid, start4, count4, intArray4d)
             end if
+#endif
          end if
       end if
 
 !      call mpas_log_write('Checking for error')
+#ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+      if (local_ierr /= SMIOL_SUCCESS) then
+         call mpas_log_write('SMIOLf_get_var failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         if (local_ierr == SMIOL_LIBRARY_ERROR) then
+            call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+         else
+            call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+         end if
+
+         io_global_err = local_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+         return
+      end if
+#endif
 
    end subroutine MPAS_io_get_var_generic
 
@@ -2289,22 +3021,23 @@ module mpas_io
 
       type (MPAS_IO_Handle_type), intent(inout) :: handle
       character (len=*), intent(in) :: fieldname
-      integer, intent(in), optional :: intVal
-      integer, dimension(:), intent(in), optional :: intArray1d
-      integer, dimension(:,:), intent(in), optional :: intArray2d
-      integer, dimension(:,:,:), intent(in), optional :: intArray3d
-      integer, dimension(:,:,:,:), intent(in), optional :: intArray4d
-      real (kind=RKIND), intent(in), optional :: realVal
-      real (kind=RKIND), dimension(:), intent(in), optional :: realArray1d
-      real (kind=RKIND), dimension(:,:), intent(in), optional :: realArray2d
-      real (kind=RKIND), dimension(:,:,:), intent(in), optional :: realArray3d
-      real (kind=RKIND), dimension(:,:,:,:), intent(in), optional :: realArray4d
-      real (kind=RKIND), dimension(:,:,:,:,:), intent(in), optional :: realArray5d
-      character (len=*), intent(in), optional :: charVal
-      character (len=*), dimension(:), intent(in), optional :: charArray1d
+      integer, intent(in), target, optional :: intVal
+      integer, dimension(:), intent(in), target, optional :: intArray1d
+      integer, dimension(:,:), intent(in), target, optional :: intArray2d
+      integer, dimension(:,:,:), intent(in), target, optional :: intArray3d
+      integer, dimension(:,:,:,:), intent(in), target, optional :: intArray4d
+      real (kind=RKIND), intent(in), target, optional :: realVal
+      real (kind=RKIND), dimension(:), intent(in), target, optional :: realArray1d
+      real (kind=RKIND), dimension(:,:), intent(in), target, optional :: realArray2d
+      real (kind=RKIND), dimension(:,:,:), intent(in), target, optional :: realArray3d
+      real (kind=RKIND), dimension(:,:,:,:), intent(in), target, optional :: realArray4d
+      real (kind=RKIND), dimension(:,:,:,:,:), intent(in), target, optional :: realArray5d
+      character (len=*), intent(in), target, optional :: charVal
+      character (len=*), dimension(:), intent(in), target, optional :: charArray1d
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
+      integer :: local_ierr
       integer, dimension(1) :: start1
       integer, dimension(1) :: count1
       integer, dimension(2) :: start2
@@ -2321,19 +3054,44 @@ module mpas_io
 
       integer :: i
 
-      real (kind=R4KIND) :: singleVal
-      real (kind=R4KIND), dimension(:), allocatable :: singleArray1d
-      real (kind=R4KIND), dimension(:,:), allocatable :: singleArray2d
-      real (kind=R4KIND), dimension(:,:,:), allocatable :: singleArray3d
-      real (kind=R4KIND), dimension(:,:,:,:), allocatable :: singleArray4d
-      real (kind=R4KIND), dimension(:,:,:,:,:), allocatable :: singleArray5d
+      real (kind=R4KIND), target :: singleVal_target
+      real (kind=R4KIND), pointer :: singleVal
+      real (kind=R4KIND), dimension(:), pointer :: singleArray1d
+      real (kind=R4KIND), dimension(:,:), pointer :: singleArray2d
+      real (kind=R4KIND), dimension(:,:,:), pointer :: singleArray3d
+      real (kind=R4KIND), dimension(:,:,:,:), pointer :: singleArray4d
+      real (kind=R4KIND), dimension(:,:,:,:,:), pointer :: singleArray5d
 
-      real (kind=R8KIND) :: doubleVal
-      real (kind=R8KIND), dimension(:), allocatable :: doubleArray1d
-      real (kind=R8KIND), dimension(:,:), allocatable :: doubleArray2d
-      real (kind=R8KIND), dimension(:,:,:), allocatable :: doubleArray3d
-      real (kind=R8KIND), dimension(:,:,:,:), allocatable :: doubleArray4d
-      real (kind=R8KIND), dimension(:,:,:,:,:), allocatable :: doubleArray5d
+      real (kind=R8KIND), target :: doubleVal_target
+      real (kind=R8KIND), pointer :: doubleVal
+      real (kind=R8KIND), dimension(:), pointer :: doubleArray1d
+      real (kind=R8KIND), dimension(:,:), pointer :: doubleArray2d
+      real (kind=R8KIND), dimension(:,:,:), pointer :: doubleArray3d
+      real (kind=R8KIND), dimension(:,:,:,:), pointer :: doubleArray4d
+      real (kind=R8KIND), dimension(:,:,:,:,:), pointer :: doubleArray5d
+
+      integer, pointer :: intVal_p
+      integer, dimension(:), pointer :: intArray1d_p
+      integer, dimension(:,:), pointer :: intArray2d_p
+      integer, dimension(:,:,:), pointer :: intArray3d_p
+      integer, dimension(:,:,:,:), pointer :: intArray4d_p
+      real (kind=RKIND), pointer :: realVal_p
+      real (kind=RKIND), dimension(:), pointer :: realArray1d_p
+      real (kind=RKIND), dimension(:,:), pointer :: realArray2d_p
+      real (kind=RKIND), dimension(:,:,:), pointer :: realArray3d_p
+      real (kind=RKIND), dimension(:,:,:,:), pointer :: realArray4d_p
+      real (kind=RKIND), dimension(:,:,:,:,:), pointer :: realArray5d_p
+      character (len=:), pointer :: charVal_p
+      character (len=:), dimension(:), pointer :: charArray1d_p
+
+#ifdef MPAS_SMIOL_SUPPORT
+      type (SMIOLf_decomp), pointer :: null_decomp
+
+      nullify(null_decomp)
+#endif
+
+      singleVal => singleVal_target
+      doubleVal => doubleVal_target
 
       ! Sanity checks
       if (.not. handle % initialized) then
@@ -2344,6 +3102,7 @@ module mpas_io
       if (.not. handle % data_mode) then
          handle % data_mode = .true.
 
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_enddef(handle % pio_file)
          ! If we are working with a preexisting file, we likely didn't define
          ! new dimensions or variables, in which case PIO_enddef() will return
@@ -2351,10 +3110,11 @@ module mpas_io
          ! pre-existing files.
          if (pio_ierr /= PIO_noerr .and. &
              .not. (handle % external_file_desc .or. handle % preexisting_file)) then
-            pio_global_ierr = pio_ierr
-            if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+            io_global_err = pio_ierr
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
             return
          end if
+#endif
       end if
 
 !     call mpas_log_write('Writing '//trim(fieldname))
@@ -2376,11 +3136,30 @@ module mpas_io
 
       if (field_cursor % fieldhandle % has_unlimited_dim) then
 
+#ifdef MPAS_PIO_SUPPORT
 #ifdef USE_PIO2
          call PIO_setframe(handle % pio_file, field_cursor % fieldhandle % field_desc, handle % frame_number)
 #else
          call PIO_setframe(field_cursor % fieldhandle % field_desc, handle % frame_number)
 #endif
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+         local_ierr = SMIOLf_set_frame(handle % smiol_file, int(handle % frame_number - 1, kind=SMIOL_offset_kind))
+         if (local_ierr /= SMIOL_SUCCESS) then
+            call mpas_log_write('SMIOLf_set_frame failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+            if (local_ierr == SMIOL_LIBRARY_ERROR) then
+               call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+            else
+               call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+            end if
+
+            io_global_err = local_ierr
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+            return
+         end if
+#endif
+
          start1(1) = handle % frame_number
          count1(1) = 1
      
@@ -2396,33 +3175,60 @@ module mpas_io
          if ((field_cursor % fieldhandle % precision == MPAS_IO_SINGLE_PRECISION) .and. &
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
             singleVal = real(realVal,R4KIND)
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, singleVal)
             else
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, singleVal)
             end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, singleVal)
+#endif
          else if ((field_cursor % fieldhandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
             doubleVal = real(realVal,R8KIND)
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, doubleVal)
             else
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, doubleVal)
             end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, doubleVal)
+#endif
          else
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, realVal)
             else
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, realVal)
             end if
+#endif
+
+            realVal_p => realVal
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, realVal_p)
+#endif
          end if
       else if (present(intVal)) then
+#ifdef MPAS_PIO_SUPPORT
          if (field_cursor % fieldhandle % has_unlimited_dim) then
             pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, intVal)
          else
             pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, intVal)
          end if
+#endif
+
+         intVal_p => intVal
+#ifdef MPAS_SMIOL_SUPPORT
+         local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, intVal_p)
+#endif
       else if (present(charVal)) then
+#ifdef MPAS_PIO_SUPPORT
          if (field_cursor % fieldhandle % has_unlimited_dim) then
             count2(1) = field_cursor % fieldhandle % dims(1) % dimsize
             pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start2, charVal(1:count2(1)))
@@ -2431,7 +3237,14 @@ module mpas_io
             count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
             pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, charVal(1:count1(1)))
          end if
+#endif
+
+         charVal_p => charVal
+#ifdef MPAS_SMIOL_SUPPORT
+         local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, charVal_p)
+#endif
       else if (present(charArray1d)) then
+#ifdef MPAS_PIO_SUPPORT
          if (field_cursor % fieldhandle % has_unlimited_dim) then
             ! Write one string at a time because the sizes differ so much (i.e. StrLen != StrKIND)
             do i = 1, field_cursor % fieldhandle % dims(2) % dimsize
@@ -2453,15 +3266,27 @@ module mpas_io
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start2, charArray1d(i)(1:count2(1)))
             end do
          end if
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+         call mpas_log_write('1-d char variables not yet implemented in SMIOL: '//trim(fieldname), messageType=MPAS_LOG_ERR)
+#endif
       else if (present(realArray1d)) then
          if ((field_cursor % fieldhandle % precision == MPAS_IO_SINGLE_PRECISION) .and. &
              (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
             allocate(singleArray1d(size(realArray1d)))
             singleArray1d(:) = real(realArray1d(:),R4KIND)
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      singleArray1d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, singleArray1d)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start2(1) = 1
                   start2(2) = handle % frame_number
@@ -2473,6 +3298,11 @@ module mpas_io
                   count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, count1, singleArray1d)
                end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, singleArray1d)
+#endif
             end if
             deallocate(singleArray1d)
          else if ((field_cursor % fieldhandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
@@ -2480,9 +3310,17 @@ module mpas_io
             allocate(doubleArray1d(size(realArray1d)))
             doubleArray1d(:) = real(realArray1d(:),R8KIND)
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      doubleArray1d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, doubleArray1d)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start2(1) = 1
                   start2(2) = handle % frame_number
@@ -2494,13 +3332,27 @@ module mpas_io
                   count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, count1, doubleArray1d)
                end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, doubleArray1d)
+#endif
             end if
             deallocate(doubleArray1d)
          else
+            realArray1d_p => realArray1d
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      realArray1d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, realArray1d_p)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start2(1) = 1
                   start2(2) = handle % frame_number
@@ -2512,6 +3364,11 @@ module mpas_io
                   count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, count1, realArray1d)
                end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, realArray1d_p)
+#endif
             end if
          end if
       else if (present(realArray2d)) then
@@ -2520,9 +3377,17 @@ module mpas_io
             allocate(singleArray2d(size(realArray2d,1), size(realArray2d,2)))
             singleArray2d(:,:) = real(realArray2d(:,:),R4KIND)
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      singleArray2d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, singleArray2d)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start3(1) = 1
                   start3(2) = 1
@@ -2537,6 +3402,11 @@ module mpas_io
                   count2(2) = field_cursor % fieldhandle % dims(2) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start2, count2, singleArray2d)
                end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, singleArray2d)
+#endif
             end if
             deallocate(singleArray2d)
          else if ((field_cursor % fieldhandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
@@ -2544,9 +3414,17 @@ module mpas_io
             allocate(doubleArray2d(size(realArray2d,1), size(realArray2d,2)))
             doubleArray2d(:,:) = real(realArray2d(:,:),R8KIND)
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      doubleArray2d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, doubleArray2d)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start3(1) = 1
                   start3(2) = 1
@@ -2561,13 +3439,27 @@ module mpas_io
                   count2(2) = field_cursor % fieldhandle % dims(2) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start2, count2, doubleArray2d)
                end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, doubleArray2d)
+#endif
             end if
             deallocate(doubleArray2d)
          else
+            realArray2d_p => realArray2d
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      realArray2d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, realArray2d_p)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start3(1) = 1
                   start3(2) = 1
@@ -2582,6 +3474,11 @@ module mpas_io
                   count2(2) = field_cursor % fieldhandle % dims(2) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start2, count2, realArray2d)
                end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, realArray2d_p)
+#endif
             end if
          end if
       else if (present(realArray3d)) then
@@ -2590,9 +3487,17 @@ module mpas_io
             allocate(singleArray3d(size(realArray3d,1), size(realArray3d,2), size(realArray3d,3)))
             singleArray3d(:,:,:) = real(realArray3d(:,:,:),R4KIND)
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      singleArray3d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, singleArray3d)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start4(1) = 1
                   start4(2) = 1
@@ -2610,6 +3515,11 @@ module mpas_io
                   count3(3) = field_cursor % fieldhandle % dims(3) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start3, count3, singleArray3d)
                end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, singleArray3d)
+#endif
             end if
             deallocate(singleArray3d)
          else if ((field_cursor % fieldhandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
@@ -2617,9 +3527,17 @@ module mpas_io
             allocate(doubleArray3d(size(realArray3d,1), size(realArray3d,2), size(realArray3d,3)))
             doubleArray3d(:,:,:) = real(realArray3d(:,:,:),R8KIND)
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      doubleArray3d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, doubleArray3d)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start4(1) = 1
                   start4(2) = 1
@@ -2637,13 +3555,27 @@ module mpas_io
                   count3(3) = field_cursor % fieldhandle % dims(3) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start3, count3, doubleArray3d)
                end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, doubleArray3d)
+#endif
             end if
             deallocate(doubleArray3d)
          else
+            realArray3d_p => realArray3d
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      realArray3d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, realArray3d_p)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start4(1) = 1
                   start4(2) = 1
@@ -2661,6 +3593,11 @@ module mpas_io
                   count3(3) = field_cursor % fieldhandle % dims(3) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start3, count3, realArray3d)
                end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, realArray3d_p)
+#endif
             end if
          end if
       else if (present(realArray4d)) then
@@ -2669,9 +3606,17 @@ module mpas_io
             allocate(singleArray4d(size(realArray4d,1), size(realArray4d,2), size(realArray4d,3), size(realArray4d,4)))
             singleArray4d(:,:,:,:) = real(realArray4d(:,:,:,:),R4KIND)
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      singleArray4d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, singleArray4d)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start5(1) = 1
                   start5(2) = 1
@@ -2692,6 +3637,11 @@ module mpas_io
                   count4(4) = field_cursor % fieldhandle % dims(4) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start4, count4, singleArray4d)
                end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, singleArray4d)
+#endif
             end if
             deallocate(singleArray4d)
          else if ((field_cursor % fieldhandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
@@ -2699,9 +3649,17 @@ module mpas_io
             allocate(doubleArray4d(size(realArray4d,1), size(realArray4d,2), size(realArray4d,3), size(realArray4d,4)))
             doubleArray4d(:,:,:,:) = real(realArray4d(:,:,:,:),R8KIND)
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      doubleArray4d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, doubleArray4d)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start5(1) = 1
                   start5(2) = 1
@@ -2722,13 +3680,27 @@ module mpas_io
                   count4(4) = field_cursor % fieldhandle % dims(4) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start4, count4, doubleArray4d)
                end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, doubleArray4d)
+#endif
             end if
             deallocate(doubleArray4d)
          else
+            realArray4d_p => realArray4d
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      realArray4d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, realArray4d_p)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start5(1) = 1
                   start5(2) = 1
@@ -2749,6 +3721,11 @@ module mpas_io
                   count4(4) = field_cursor % fieldhandle % dims(4) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start4, count4, realArray4d)
                end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, realArray4d_p)
+#endif
             end if
          end if
       else if (present(realArray5d)) then
@@ -2757,9 +3734,17 @@ module mpas_io
             allocate(singleArray5d(size(realArray5d,1), size(realArray5d,2), size(realArray5d,3), size(realArray5d,4), size(realArray5d,5)))
             singleArray5d(:,:,:,:,:) = real(realArray5d(:,:,:,:,:),R4KIND)
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      singleArray5d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, singleArray5d)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start6(1) = 1
                   start6(2) = 1
@@ -2783,6 +3768,11 @@ module mpas_io
                   count5(5) = field_cursor % fieldhandle % dims(5) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start5, count5, singleArray5d)
                end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, singleArray5d)
+#endif
             end if
             deallocate(singleArray5d)
          else if ((field_cursor % fieldhandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
@@ -2790,9 +3780,17 @@ module mpas_io
             allocate(doubleArray5d(size(realArray5d,1), size(realArray5d,2), size(realArray5d,3), size(realArray5d,4), size(realArray5d,5)))
             doubleArray5d(:,:,:,:,:) = real(realArray5d(:,:,:,:,:),R8KIND)
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      doubleArray5d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, doubleArray5d)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start6(1) = 1
                   start6(2) = 1
@@ -2816,13 +3814,27 @@ module mpas_io
                   count5(5) = field_cursor % fieldhandle % dims(5) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start5, count5, doubleArray5d)
                end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, doubleArray5d)
+#endif
             end if
             deallocate(doubleArray5d)
          else
+            realArray5d_p => realArray5d
             if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
                call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                      realArray5d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                           field_cursor % fieldhandle % decomp % smiol_decomp, realArray5d_p)
+#endif
             else
+#ifdef MPAS_PIO_SUPPORT
                if (field_cursor % fieldhandle % has_unlimited_dim) then
                   start6(1) = 1
                   start6(2) = 1
@@ -2846,13 +3858,27 @@ module mpas_io
                   count5(5) = field_cursor % fieldhandle % dims(5) % dimsize
                   pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start5, count5, realArray5d)
                end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+               local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, realArray5d_p)
+#endif
             end if
          end if
       else if (present(intArray1d)) then
+         intArray1d_p => intArray1d
          if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
             call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                   intArray1d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                        field_cursor % fieldhandle % decomp % smiol_decomp, intArray1d_p)
+#endif
          else
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                start2(1) = 1
                start2(2) = handle % frame_number
@@ -2864,12 +3890,26 @@ module mpas_io
                count1(1) = field_cursor % fieldhandle % dims(1) % dimsize
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start1, count1, intArray1d)
             end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, intArray1d_p)
+#endif
          end if
       else if (present(intArray2d)) then
+         intArray2d_p => intArray2d
          if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
             call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                   intArray2d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                        field_cursor % fieldhandle % decomp % smiol_decomp, intArray2d_p)
+#endif
          else
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                start3(1) = 1
                start3(2) = 1
@@ -2884,12 +3924,26 @@ module mpas_io
                count2(2) = field_cursor % fieldhandle % dims(2) % dimsize
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start2, count2, intArray2d)
             end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, intArray2d_p)
+#endif
          end if
       else if (present(intArray3d)) then
+         intArray3d_p => intArray3d
          if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
             call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                   intArray3d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                        field_cursor % fieldhandle % decomp % smiol_decomp, intArray3d_p)
+#endif
          else
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                start4(1) = 1
                start4(2) = 1
@@ -2907,12 +3961,26 @@ module mpas_io
                count3(3) = field_cursor % fieldhandle % dims(3) % dimsize
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start3, count3, intArray3d)
             end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, intArray3d_p)
+#endif
          end if
       else if (present(intArray4d)) then
+         intArray4d_p => intArray4d
          if (associated(field_cursor % fieldhandle % decomp)) then
+#ifdef MPAS_PIO_SUPPORT
             call PIO_write_darray(handle % pio_file, field_cursor % fieldhandle % field_desc, field_cursor % fieldhandle % decomp % pio_iodesc, &
                                   intArray4d, pio_ierr)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), &
+                                        field_cursor % fieldhandle % decomp % smiol_decomp, intArray4d_p)
+#endif
          else
+#ifdef MPAS_PIO_SUPPORT
             if (field_cursor % fieldhandle % has_unlimited_dim) then
                start5(1) = 1
                start5(2) = 1
@@ -2933,13 +4001,34 @@ module mpas_io
                count4(4) = field_cursor % fieldhandle % dims(4) % dimsize
                pio_ierr = PIO_put_var(handle % pio_file, field_cursor % fieldhandle % field_desc, start4, count4, intArray4d)
             end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_put_var(handle % smiol_file, trim(fieldname), null_decomp, intArray4d_p)
+#endif
          end if
       end if
+#ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+      if (local_ierr /= SMIOL_SUCCESS) then
+         call mpas_log_write('SMIOLf_put_var failed with error $i : '//trim(fieldname), intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         if (local_ierr == SMIOL_LIBRARY_ERROR) then
+            call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+         else
+            call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+         end if
+
+         io_global_err = local_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+         return
+      end if
+#endif
 
    end subroutine MPAS_io_put_var_generic
 
@@ -3176,6 +4265,7 @@ module mpas_io
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
+      integer :: local_ierr
       integer :: varid
       integer :: xtype
 #ifdef USE_PIO2
@@ -3245,14 +4335,17 @@ module mpas_io
             att_cursor => att_cursor % next
          end do
 
+#ifdef MPAS_PIO_SUPPORT
          varid = PIO_global
+#endif
       end if
 
       ! Query attribute value
+#ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
       if (xtype /= PIO_int) then
@@ -3262,10 +4355,29 @@ module mpas_io
 
       pio_ierr = PIO_get_att(handle % pio_file, varid, attName, attValue)
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+      if (present(fieldname)) then
+         local_ierr = SMIOLf_inquire_att(handle % smiol_file, trim(fieldname), trim(attName), attValue)
+      else
+         local_ierr = SMIOLf_inquire_att(handle % smiol_file, '', trim(attName), attValue)
+      end if
+      if (local_ierr /= SMIOL_SUCCESS) then
+         if (local_ierr == SMIOL_WRONG_ARG_TYPE) then
+            if (present(ierr)) ierr = MPAS_IO_ERR_WRONG_ATT_TYPE
+            return
+         else
+            io_global_err = local_ierr
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+            return
+         end if
+      end if
+#endif
 
       ! Keep attribute for future reference
       allocate(new_att_node)
@@ -3336,6 +4448,9 @@ module mpas_io
          return 
       end if
 
+#ifdef MPAS_SMIOL_SUPPORT
+     call mpas_log_write('1-d integer attributes not yet implemented in SMIOL: '//trim(attName), messageType=MPAS_LOG_ERR)
+#endif
 
       !
       ! For variable attributes, find the structure for fieldname
@@ -3388,14 +4503,17 @@ module mpas_io
             att_cursor => att_cursor % next
          end do
 
+#ifdef MPAS_PIO_SUPPORT
          varid = PIO_global
+#endif
       end if
 
       ! Query attribute value
+#ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 
@@ -3406,18 +4524,19 @@ module mpas_io
 
       pio_ierr = PIO_inq_attlen(handle % pio_file, varid, attName, attlen)
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 
       allocate(attValue(attlen))
       pio_ierr = PIO_get_att(handle % pio_file, varid, attName, attValue)
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
+#endif
 
       ! Keep attribute for future reference
       allocate(new_att_node)
@@ -3471,6 +4590,7 @@ module mpas_io
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
+      integer :: local_ierr
       integer :: varid
       integer :: local_precision
       real (kind=R4KIND) :: singleVal
@@ -3543,7 +4663,9 @@ module mpas_io
             att_cursor => att_cursor % next
          end do
 
+#ifdef MPAS_PIO_SUPPORT
          varid = PIO_global
+#endif
       end if
 
       if (present(precision)) then
@@ -3552,11 +4674,12 @@ module mpas_io
          local_precision = MPAS_IO_NATIVE_PRECISION
       end if
 
+#ifdef MPAS_PIO_SUPPORT
       ! Query attribute value
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 
@@ -3568,6 +4691,7 @@ module mpas_io
             return
          end if
          pio_ierr = PIO_get_att(handle % pio_file, varid, attName, singleVal)
+
          attValue = real(singleVal,RKIND)
 
       else if ((local_precision == MPAS_IO_DOUBLE_PRECISION) .and. &
@@ -3578,6 +4702,7 @@ module mpas_io
             return
          end if
          pio_ierr = PIO_get_att(handle % pio_file, varid, attName, doubleVal)
+
          attValue = real(doubleVal,RKIND)
 
       else
@@ -3590,10 +4715,76 @@ module mpas_io
 
       end if
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+      !
+      ! Try to read the attribute in the MPAS native precision
+      !
+      if (present(fieldname)) then
+         local_ierr = SMIOLf_inquire_att(handle % smiol_file, trim(fieldname), &
+                                         trim(attName), attValue)
+      else
+         local_ierr = SMIOLf_inquire_att(handle % smiol_file, '', &
+                                         trim(attName), attValue)
+      end if
+
+      !
+      ! If that fails, perhaps the attribute is in a different precision from
+      ! the native MPAS precision
+      !
+      if (local_ierr == SMIOL_WRONG_ARG_TYPE) then
+         if (MPAS_IO_NATIVE_PRECISION == MPAS_IO_DOUBLE_PRECISION) then
+
+            !
+            ! Try again, but read a single-precision value
+            !
+            if (present(fieldname)) then
+               local_ierr = SMIOLf_inquire_att(handle % smiol_file, trim(fieldname), &
+                                               trim(attName), singleVal)
+            else
+               local_ierr = SMIOLf_inquire_att(handle % smiol_file, '', &
+                                               trim(attName), singleVal)
+            end if
+            attValue = real(singleVal,RKIND)
+
+         else
+
+            !
+            ! Try again, but read a double-precision value
+            !
+            if (present(fieldname)) then
+               local_ierr = SMIOLf_inquire_att(handle % smiol_file, trim(fieldname), &
+                                               trim(attName), doubleVal)
+            else
+               local_ierr = SMIOLf_inquire_att(handle % smiol_file, '', &
+                                               trim(attName), doubleVal)
+            end if
+            attValue = real(doubleVal,RKIND)
+
+         end if
+      end if
+
+      !
+      ! If all of the above were unsuccessful, set attValue to a fill value
+      ! and return an error
+      !
+      if (local_ierr /= SMIOL_SUCCESS) then
+         attValue = MPAS_REAL_FILLVAL
+         if (local_ierr == SMIOL_WRONG_ARG_TYPE) then
+            if (present(ierr)) ierr = MPAS_IO_ERR_WRONG_ATT_TYPE
+         else
+            io_global_err = local_ierr
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+            return
+         end if
+         return
+      end if
+#endif
 
       ! Keep attribute for future reference
       allocate(new_att_node)
@@ -3669,6 +4860,9 @@ module mpas_io
          return 
       end if
 
+#ifdef MPAS_SMIOL_SUPPORT
+      call mpas_log_write('1-d real attributes not yet implemented in SMIOL: '//trim(attName), messageType=MPAS_LOG_ERR)
+#endif
 
       !
       ! For variable attributes, find the structure for fieldname
@@ -3721,7 +4915,9 @@ module mpas_io
             att_cursor => att_cursor % next
          end do
 
+#ifdef MPAS_PIO_SUPPORT
          varid = PIO_global
+#endif
       end if
 
       if (present(precision)) then
@@ -3731,17 +4927,18 @@ module mpas_io
       end if
 
       ! Query attribute value
+#ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 
       pio_ierr = PIO_inq_attlen(handle % pio_file, varid, attName, attlen)
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
 
@@ -3782,10 +4979,11 @@ module mpas_io
 
       end if
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
+#endif
 
       ! Keep attribute for future reference
       allocate(new_att_node)
@@ -3839,6 +5037,7 @@ module mpas_io
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
+      integer :: local_ierr
       integer :: varid
       integer :: xtype
 #ifdef USE_PIO2
@@ -3908,14 +5107,17 @@ module mpas_io
             att_cursor => att_cursor % next
          end do
 
+#ifdef MPAS_PIO_SUPPORT
          varid = PIO_global
+#endif
       end if
 
       ! Query attribute value
+#ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_inq_att(handle % pio_file, varid, attName, xtype, len)
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
       if (xtype /= PIO_char) then
@@ -3925,10 +5127,29 @@ module mpas_io
 
       pio_ierr = PIO_get_att(handle % pio_file, varid, attName, attValue)
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+      if (present(fieldname)) then
+         local_ierr = SMIOLf_inquire_att(handle % smiol_file, trim(fieldname), trim(attName), attValue)
+      else
+         local_ierr = SMIOLf_inquire_att(handle % smiol_file, '', trim(attName), attValue)
+      end if
+      if (local_ierr /= SMIOL_SUCCESS) then
+         if (local_ierr == SMIOL_WRONG_ARG_TYPE) then
+            if (present(ierr)) ierr = MPAS_IO_ERR_WRONG_ATT_TYPE
+            return
+         else
+            io_global_err = local_ierr
+            if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+            return
+         end if
+      end if
+#endif
 
       ! Keep attribute for future reference
       allocate(new_att_node)
@@ -3981,6 +5202,7 @@ module mpas_io
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
+      integer :: local_ierr
       integer :: varid
       integer :: attValueLocal
       type (fieldlist_type), pointer :: field_cursor
@@ -4082,7 +5304,9 @@ module mpas_io
             attlist_cursor => attlist_cursor % next
          end do
 
+#ifdef MPAS_PIO_SUPPORT
          varid = PIO_global
+#endif
 
          ! Add attribute to global attribute list
          if (.not. associated(handle % attlist_head)) then
@@ -4105,12 +5329,34 @@ module mpas_io
          end if
       end if
 
+#ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+      if (present(fieldname)) then
+         local_ierr = SMIOLf_define_att(handle % smiol_file, trim(fieldname), trim(attName), attValueLocal)
+      else
+         local_ierr = SMIOLf_define_att(handle % smiol_file, '', trim(attName), attValueLocal)
+      end if
+      if (local_ierr /= SMIOL_SUCCESS) then
+         call mpas_log_write('SMIOLf_define_att failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         if (local_ierr == SMIOL_LIBRARY_ERROR) then
+            call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+         else
+            call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+         end if
+
+         io_global_err = local_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+         return
+      end if
+#endif
 
       ! Maybe we should add attribute to list only after a successfull call to PIO?
 
@@ -4154,6 +5400,9 @@ module mpas_io
          return 
       end if
 
+#ifdef MPAS_SMIOL_SUPPORT
+      call mpas_log_write('1-d integer attributes not yet implemented in SMIOL: '//trim(attName), messageType=MPAS_LOG_ERR)
+#endif
 
       allocate(new_attlist_node) 
       nullify(new_attlist_node % next)
@@ -4240,7 +5489,9 @@ module mpas_io
             attlist_cursor => attlist_cursor % next
          end do
 
+#ifdef MPAS_PIO_SUPPORT
          varid = PIO_global
+#endif
 
          ! Add attribute to global attribute list
          if (.not. associated(handle % attlist_head)) then
@@ -4263,12 +5514,14 @@ module mpas_io
          end if
       end if
 
+#ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
+#endif
 
       deallocate(attValueLocal)
 
@@ -4290,6 +5543,7 @@ module mpas_io
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
+      integer :: local_ierr
       integer :: varid
       real (kind=RKIND) :: attValueLocal
       real (kind=R4KIND) :: singleVal
@@ -4398,7 +5652,9 @@ module mpas_io
             attlist_cursor => attlist_cursor % next
          end do
 
+#ifdef MPAS_PIO_SUPPORT
          varid = PIO_global
+#endif
 
          ! Add attribute to global attribute list
          if (.not. associated(handle % attlist_head)) then
@@ -4424,20 +5680,66 @@ module mpas_io
       if ((new_attlist_node % attHandle % precision == MPAS_IO_SINGLE_PRECISION) .and. &
           (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
          singleVal = real(attValueLocal,R4KIND)
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_put_att(handle % pio_file, varid, attName, singleVal) 
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+         if (present(fieldname)) then
+            local_ierr = SMIOLf_define_att(handle % smiol_file, trim(fieldname), trim(attName), singleVal)
+         else
+            local_ierr = SMIOLf_define_att(handle % smiol_file, '', trim(attName), singleVal)
+         end if
+#endif
       else if ((new_attlist_node % attHandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
           (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
          doubleVal = real(attValueLocal,R8KIND)
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_put_att(handle % pio_file, varid, attName, doubleVal) 
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+         if (present(fieldname)) then
+            local_ierr = SMIOLf_define_att(handle % smiol_file, trim(fieldname), trim(attName), doubleVal)
+         else
+            local_ierr = SMIOLf_define_att(handle % smiol_file, '', trim(attName), doubleVal)
+         end if
+#endif
       else
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+         if (present(fieldname)) then
+            local_ierr = SMIOLf_define_att(handle % smiol_file, trim(fieldname), trim(attName), attValueLocal)
+         else
+            local_ierr = SMIOLf_define_att(handle % smiol_file, '', trim(attName), attValueLocal)
+         end if
+#endif
       end if
 
+#ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+      if (local_ierr /= SMIOL_SUCCESS) then
+         call mpas_log_write('SMIOLf_define_att failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         if (local_ierr == SMIOL_LIBRARY_ERROR) then
+            call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+         else
+            call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+         end if
+
+         io_global_err = local_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+         return
+      end if
+#endif
 
       ! Maybe we should add attribute to list only after a successfull call to PIO?
 
@@ -4485,6 +5787,9 @@ module mpas_io
          return 
       end if
 
+#ifdef MPAS_SMIOL_SUPPORT
+      call mpas_log_write('1-d real attributes not yet implemented in SMIOL: '//trim(attName), messageType=MPAS_LOG_ERR)
+#endif
 
       allocate(new_attlist_node) 
       nullify(new_attlist_node % next)
@@ -4576,7 +5881,9 @@ module mpas_io
             attlist_cursor => attlist_cursor % next
          end do
 
+#ifdef MPAS_PIO_SUPPORT
          varid = PIO_global
+#endif
 
          ! Add attribute to global attribute list
          if (.not. associated(handle % attlist_head)) then
@@ -4603,22 +5910,30 @@ module mpas_io
           (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_SINGLE_PRECISION)) then
          allocate(singleVal(size(attValueLocal)))
          singleVal(:) = real(attValueLocal(:),R4KIND)
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_put_att(handle % pio_file, varid, attName, singleVal) 
+#endif
          deallocate(singleVal)
       else if ((new_attlist_node % attHandle % precision == MPAS_IO_DOUBLE_PRECISION) .and. &
           (MPAS_IO_NATIVE_PRECISION /= MPAS_IO_DOUBLE_PRECISION)) then
          allocate(doubleVal(size(attValueLocal)))
          doubleVal(:) = real(attValueLocal(:),R8KIND)
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_put_att(handle % pio_file, varid, attName, doubleVal) 
+#endif
          deallocate(doubleVal)
       else
+#ifdef MPAS_PIO_SUPPORT
          pio_ierr = PIO_put_att(handle % pio_file, varid, attName, attValueLocal) 
+#endif
       end if
+#ifdef MPAS_PIO_SUPPORT
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
          return
       end if
+#endif
 
       deallocate(attValueLocal)
 
@@ -4639,6 +5954,7 @@ module mpas_io
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
+      integer :: local_ierr
       integer :: varid
       integer :: valLen
       character (len=StrKind) :: attValueLocal, trimmedVal
@@ -4750,7 +6066,9 @@ module mpas_io
             attlist_cursor => attlist_cursor % next
          end do
 
+#ifdef MPAS_PIO_SUPPORT
          varid = PIO_global
+#endif
 
          ! Add attribute to global attribute list
          if (.not. associated(handle % attlist_head)) then
@@ -4773,11 +6091,12 @@ module mpas_io
          end if
       end if
 
+#ifdef MPAS_PIO_SUPPORT
       pio_ierr = PIO_put_att(handle % pio_file, varid, attName, trim(attValueLocal)) 
       if (pio_ierr /= PIO_noerr) then
-         pio_global_ierr = pio_ierr
 
-         if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+         io_global_err = pio_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
 
          !
          ! If we are working with a pre-existing file and the text attribute is larger than in the file, we need 
@@ -4788,19 +6107,19 @@ module mpas_io
          if (handle % preexisting_file .and. .not. handle % data_mode) then
             pio_ierr = PIO_redef(handle % pio_file)
             if (pio_ierr /= PIO_noerr) then
-               pio_global_ierr = pio_ierr
+               io_global_err = pio_ierr
                return
             end if
 
             pio_ierr = PIO_put_att(handle % pio_file, varid, attName, trim(attValueLocal)) 
             if (pio_ierr /= PIO_noerr) then
-               pio_global_ierr = pio_ierr
+               io_global_err = pio_ierr
                return
             end if
 
             pio_ierr = PIO_enddef(handle % pio_file)
             if (pio_ierr /= PIO_noerr) then
-               pio_global_ierr = pio_ierr
+               io_global_err = pio_ierr
                return
             end if
 
@@ -4810,6 +6129,27 @@ module mpas_io
 
          return
       end if
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+      if (present(fieldname)) then
+         local_ierr = SMIOLf_define_att(handle % smiol_file, trim(fieldname), trim(attName), trim(attValueLocal))
+      else
+         local_ierr = SMIOLf_define_att(handle % smiol_file, '', trim(attName), trim(attValueLocal))
+      end if
+      if (local_ierr /= SMIOL_SUCCESS) then
+         call mpas_log_write('SMIOLf_define_att failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         if (local_ierr == SMIOL_LIBRARY_ERROR) then
+            call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+         else
+            call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+         end if
+
+         io_global_err = local_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+         return
+      end if
+#endif
 
       ! Maybe we should add attribute to list only after a successfull call to PIO?
 
@@ -4854,6 +6194,8 @@ module mpas_io
       type (MPAS_IO_Handle_type), intent(inout) :: handle
       integer, intent(out), optional :: ierr
 
+      integer :: local_ierr
+
 !      call mpas_log_write('Called MPAS_io_sync()')
       if (present(ierr)) ierr = MPAS_IO_NOERR
 
@@ -4863,7 +6205,25 @@ module mpas_io
          return 
       end if
 
+#ifdef MPAS_PIO_SUPPORT
       call PIO_syncfile(handle % pio_file)
+#endif
+
+#ifdef MPAS_SMIOL_SUPPORT
+      local_ierr = SMIOLf_sync_file(handle % smiol_file)
+      if (local_ierr /= SMIOL_SUCCESS) then
+         call mpas_log_write('SMIOLf_sync_file failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         if (local_ierr == SMIOL_LIBRARY_ERROR) then
+            call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+         else
+            call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+         end if
+
+         io_global_err = local_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+         return
+      end if
+#endif
 
    end subroutine MPAS_io_sync
 
@@ -4874,6 +6234,8 @@ module mpas_io
 
       type (MPAS_IO_Handle_type), intent(inout) :: handle
       integer, intent(out), optional :: ierr
+
+      integer :: local_ierr
 
       type (dimlist_type), pointer :: dimlist_ptr, dimlist_del
       type (fieldlist_type), pointer :: fieldlist_ptr, fieldlist_del
@@ -4936,8 +6298,25 @@ module mpas_io
 
 !call mpas_log_write('MGD PIO_closefile')
       if (.not. handle % external_file_desc) then
+#ifdef MPAS_PIO_SUPPORT
          call PIO_closefile(handle % pio_file)
+#endif
       end if
+#ifdef MPAS_SMIOL_SUPPORT
+      local_ierr = SMIOLf_close_file(handle % smiol_file)
+      if (local_ierr /= SMIOL_SUCCESS) then
+         call mpas_log_write('SMIOLf_close_file failed with error $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         if (local_ierr == SMIOL_LIBRARY_ERROR) then
+            call mpas_log_write(trim(SMIOLf_lib_error_string(handle % ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+         else
+            call mpas_log_write(trim(SMIOLf_error_string(local_ierr)), messageType=MPAS_LOG_ERR)
+         end if
+
+         io_global_err = local_ierr
+         if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+         return
+      end if
+#endif
 
    end subroutine MPAS_io_close
 
@@ -4951,6 +6330,7 @@ module mpas_io
       integer, intent(out), optional :: ierr
 
       integer :: pio_ierr
+      integer :: local_ierr
       type (decomplist_type), pointer :: decomp_cursor, decomp_del
 
 !      call mpas_log_write('Called MPAS_io_finalize()')
@@ -4964,7 +6344,15 @@ module mpas_io
 !if (.not. associated(decomp_del % decomphandle)) call mpas_log_write('OOPS... do not have decomphandle')
          deallocate(decomp_del % decomphandle % dims)
          deallocate(decomp_del % decomphandle % indices)
+#ifdef MPAS_PIO_SUPPORT
          call PIO_freedecomp(ioContext % pio_iosystem, decomp_del % decomphandle % pio_iodesc)
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+         local_ierr = SMIOLf_free_decomp(decomp_del % decomphandle % smiol_decomp)
+         if (local_ierr /= SMIOL_SUCCESS) then
+             call mpas_log_write('SMIOLf_free_decomp failed with code $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+         end if
+#endif
          deallocate(decomp_del % decomphandle)
          deallocate(decomp_del)
       end do
@@ -4972,13 +6360,24 @@ module mpas_io
 !call mpas_log_write('MGD PIO_finalize')
       if (present(finalize_iosystem)) then
          if ( finalize_iosystem ) then
+#ifdef MPAS_PIO_SUPPORT
            call PIO_finalize(ioContext % pio_iosystem, pio_ierr)
            if (pio_ierr /= PIO_noerr) then
-              pio_global_ierr = pio_ierr
-              if (present(ierr)) ierr = MPAS_IO_ERR_PIO
+              io_global_err = pio_ierr
+              if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
               return
            end if
            deallocate(ioContext % pio_iosystem)
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+            local_ierr = SMIOLf_finalize(ioContext % smiol_context)
+            if (local_ierr /= SMIOL_SUCCESS) then
+               call mpas_log_write('SMIOLf_free_decomp failed with code $i', intArgs=[local_ierr], messageType=MPAS_LOG_ERR)
+               io_global_err = local_ierr
+               if (present(ierr)) ierr = MPAS_IO_ERR_BACKEND
+               return
+            end if
+#endif
          end if
       end if
 
@@ -4996,15 +6395,18 @@ module mpas_io
    end function MPAS_io_handle_dminfo
 
 
-   subroutine MPAS_io_err_mesg(ierr, fatal)
+   subroutine MPAS_io_err_mesg(ioContext, ierr, fatal)
 
       implicit none
 
+      type (mpas_io_context_type), intent(inout) :: ioContext
       integer, intent(in) :: ierr
       logical, intent(in) :: fatal
 
+#ifdef MPAS_PIO_SUPPORT
       integer :: ierr_local
       character(len=StrKIND) :: pio_string
+#endif
 
       select case (ierr)
          case (MPAS_IO_NOERR)
@@ -5017,10 +6419,20 @@ module mpas_io
             call mpas_log_write('MPAS IO Error: Filename too long', MPAS_LOG_ERR)
          case (MPAS_IO_ERR_UNINIT_HANDLE)
             call mpas_log_write('MPAS IO Error: Uninitialized I/O handle', MPAS_LOG_ERR)
-         case (MPAS_IO_ERR_PIO)
-            ierr_local = PIO_strerror(pio_global_ierr, pio_string)
+         case (MPAS_IO_ERR_BACKEND)
+#ifdef MPAS_PIO_SUPPORT
+            ierr_local = PIO_strerror(io_global_err, pio_string)
             call mpas_log_write('MPAS IO Error: PIO error $i: '//trim(pio_string), &
-                                messageType=MPAS_LOG_ERR, intArgs=[pio_global_ierr])
+                                messageType=MPAS_LOG_ERR, intArgs=[io_global_err])
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+            call mpas_log_write('MPAS IO Error: SMIOL error $i: '//trim(SMIOLf_error_string(io_global_err)), &
+                                messageType=MPAS_LOG_ERR, intArgs=[io_global_err])
+            if (io_global_err == SMIOL_LIBRARY_ERROR) then
+               call mpas_log_write('Library error message: '// &
+                                   trim(SMIOLf_lib_error_string(ioContext % smiol_context)), messageType=MPAS_LOG_ERR)
+            end if
+#endif
          case (MPAS_IO_ERR_DATA_MODE)
             call mpas_log_write('MPAS IO Error: Cannot define in data mode', MPAS_LOG_ERR)
          case (MPAS_IO_ERR_NOWRITE)

--- a/src/framework/mpas_io_streams.F
+++ b/src/framework/mpas_io_streams.F
@@ -91,7 +91,11 @@ module mpas_io_streams
       logical, intent(in), optional :: clobberRecords
       logical, intent(in), optional :: clobberFiles
       logical, intent(in), optional :: truncateFiles
+#ifdef MPAS_PIO_SUPPORT
       type (file_desc_t), intent(inout), optional :: pio_file_desc
+#else
+      integer, optional :: pio_file_desc
+#endif
       integer, intent(out), optional :: ierr
 
       integer :: io_err
@@ -114,7 +118,7 @@ module mpas_io_streams
       end if
 
       ! General error
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR) then
          if (present(ierr)) ierr = MPAS_IO_ERR
          return
@@ -1700,7 +1704,7 @@ module mpas_io_streams
 !call mpas_log_write('... defining dimension '// trim(dimNames(idim))//" $i", intArgs=(/ dimSizes(idim)/))
             write(dimNamesLocal(idim),'(a)') dimNames(idim)
             call MPAS_io_def_dim(stream % fileHandle, trim(dimNames(idim)), dimSizes(idim), io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR) then
                if (present(ierr)) ierr = MPAS_IO_ERR
                deallocate(new_field_list_node)
@@ -1725,7 +1729,7 @@ module mpas_io_streams
          if (ndims > 0) then
 !call mpas_log_write('... defining dimension '// trim(dimNames(idim))//" $i", intArgs=(/ globalDimSize/))
             call MPAS_io_def_dim(stream % fileHandle, trim(dimNames(idim)), globalDimSize, io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR) then
                if (present(ierr)) ierr = MPAS_IO_ERR
                deallocate(new_field_list_node)
@@ -1739,7 +1743,7 @@ module mpas_io_streams
          if (hasTimeDimension) then
 !call mpas_log_write('... defining Time dimension ')
             call MPAS_io_def_dim(stream % fileHandle, 'Time', MPAS_IO_UNLIMITED_DIM, io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR) then
                if (present(ierr)) ierr = MPAS_IO_ERR
                deallocate(new_field_list_node)
@@ -1755,7 +1759,7 @@ module mpas_io_streams
 !call mpas_log_write('... defining var to low-level interface with ndims $i', intArgs=(/ndims/))
 
          call MPAS_io_def_var(stream % fileHandle, trim(fieldName), fieldType, dimNamesLocal(1:ndims), precision=precision, ierr=io_err)
-         call MPAS_io_err_mesg(io_err, .false.)
+         call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
          if (io_err /= MPAS_IO_NOERR) then
             if (present(ierr)) ierr = MPAS_IO_ERR
             deallocate(new_field_list_node)
@@ -1768,7 +1772,7 @@ module mpas_io_streams
          call MPAS_io_inq_var(stream % fileHandle, trim(fieldName), dimnames=dimNamesInq, dimsizes=dimSizesInq, ierr=io_err)
          ! If the field does not exist in the input file, we should handle this situation gracefully at higher levels
          !   without printing disconcerting error messages
-         !call MPAS_io_err_mesg(io_err, .false.)
+         !call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
          if (io_err /= MPAS_IO_NOERR) then
             if (present(ierr)) ierr = MPAS_IO_ERR
             deallocate(new_field_list_node)
@@ -1826,7 +1830,7 @@ module mpas_io_streams
       !
       if (ndims > 0 .and. isDecomposed) then
          call MPAS_io_set_var_indices(stream % fileHandle, trim(fieldName), indices, io_err)
-         call MPAS_io_err_mesg(io_err, .false.)
+         call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
          if (io_err /= MPAS_IO_NOERR) then
             if (present(ierr)) ierr = MPAS_IO_ERR
             deallocate(new_field_list_node)
@@ -2475,7 +2479,7 @@ module mpas_io_streams
       ! Set time frame to real
       !
       call MPAS_io_set_frame(stream % fileHandle, frame, io_err) 
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR) then
          if (present(ierr)) ierr = MPAS_IO_ERR
          return
@@ -2496,7 +2500,7 @@ module mpas_io_streams
 
 !call mpas_log_write('MGD calling MPAS_io_get_var now...')
             call MPAS_io_get_var(stream % fileHandle, field_cursor % int0dField % fieldName, int0d_temp, io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR) then
                 if (present(ierr)) ierr = MPAS_IO_ERR
                 return
@@ -2528,7 +2532,7 @@ module mpas_io_streams
                else
                   call MPAS_io_get_var(stream % fileHandle, field_cursor % int1dField % fieldName, int1d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR) then
                    if (present(ierr)) ierr = MPAS_IO_ERR
                    if (.not. field_cursor % int1dField % isVarArray) then
@@ -2604,7 +2608,7 @@ module mpas_io_streams
                else
                   call MPAS_io_get_var(stream % fileHandle, field_cursor % int2dField % fieldName, int2d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR) then
                    if (present(ierr)) ierr = MPAS_IO_ERR
                    if (field_cursor % int2dField % isVarArray) then
@@ -2686,7 +2690,7 @@ module mpas_io_streams
                else
                   call MPAS_io_get_var(stream % fileHandle, field_cursor % int3dField % fieldName, int3d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR) then
                    if (present(ierr)) ierr = MPAS_IO_ERR
                    if (field_cursor % int3dField % isVarArray) then
@@ -2756,7 +2760,7 @@ module mpas_io_streams
 
 !call mpas_log_write('MGD calling MPAS_io_get_var now...')
             call MPAS_io_get_var(stream % fileHandle, field_cursor % real0dField % fieldName, real0d_temp, io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR) then
                 if (present(ierr)) ierr = MPAS_IO_ERR
                 return
@@ -2788,7 +2792,7 @@ module mpas_io_streams
                else
                   call MPAS_io_get_var(stream % fileHandle, field_cursor % real1dField % fieldName, real1d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR) then
                    if (present(ierr)) ierr = MPAS_IO_ERR
                    if (.not. field_cursor % real1dField % isVarArray) then
@@ -2865,7 +2869,7 @@ module mpas_io_streams
                else
                   call MPAS_io_get_var(stream % fileHandle, field_cursor % real2dField % fieldName, real2d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR) then
                    if (present(ierr)) ierr = MPAS_IO_ERR
                    if (field_cursor % real2dField % isVarArray) then
@@ -2950,7 +2954,7 @@ module mpas_io_streams
                else
                   call MPAS_io_get_var(stream % fileHandle, field_cursor % real3dField % fieldName, real3d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR) then
                    if (present(ierr)) ierr = MPAS_IO_ERR
                    if (field_cursor % real3dField % isVarArray) then
@@ -3037,7 +3041,7 @@ module mpas_io_streams
                else
                   call MPAS_io_get_var(stream % fileHandle, field_cursor % real4dField % fieldName, real4d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR) then
                    if (present(ierr)) ierr = MPAS_IO_ERR
                    if (field_cursor % real4dField % isVarArray) then
@@ -3127,7 +3131,7 @@ module mpas_io_streams
                else
                   call MPAS_io_get_var(stream % fileHandle, field_cursor % real5dField % fieldName, real5d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR) then
                    if (present(ierr)) ierr = MPAS_IO_ERR
                    if (field_cursor % real5dField % isVarArray) then
@@ -3198,7 +3202,7 @@ module mpas_io_streams
 
 !call mpas_log_write('MGD calling MPAS_io_get_var now...')
             call MPAS_io_get_var(stream % fileHandle, field_cursor % char0dField % fieldName, field_cursor % char0dField % scalar, io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR) then
                 if (present(ierr)) ierr = MPAS_IO_ERR
                 return
@@ -3221,7 +3225,7 @@ module mpas_io_streams
 !call mpas_log_write('MGD calling MPAS_io_get_var now...')
             allocate(char1d_temp(field_cursor % char1dField % dimSizes(1)))
             call MPAS_io_get_var(stream % fileHandle, field_cursor % char1dField % fieldName, char1d_temp, io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR) then
                 if (present(ierr)) ierr = MPAS_IO_ERR
                 deallocate(char1d_temp)
@@ -3298,7 +3302,7 @@ module mpas_io_streams
       ! Set time frame to write
       !
       call MPAS_io_set_frame(stream % fileHandle, frame, io_err) 
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR) then
          if (present(ierr)) ierr = MPAS_IO_ERR
          return
@@ -3340,7 +3344,7 @@ module mpas_io_streams
 
 !call mpas_log_write('MGD calling MPAS_io_put_var now...')
             call MPAS_io_put_var(stream % fileHandle, field_cursor % int0dField % fieldName, int0d_temp, io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
          else if (field_cursor % field_type == FIELD_1D_INT) then
@@ -3397,7 +3401,7 @@ module mpas_io_streams
                else
                   call MPAS_io_put_var(stream % fileHandle, field_cursor % int1dField % fieldName, int1d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
             end do
 
@@ -3460,7 +3464,7 @@ module mpas_io_streams
                else
                   call MPAS_io_put_var(stream % fileHandle, field_cursor % int2dField % fieldName, int2d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
             end do
 
@@ -3527,7 +3531,7 @@ module mpas_io_streams
                else
                   call MPAS_io_put_var(stream % fileHandle, field_cursor % int3dField % fieldName, int3d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
             end do
 
@@ -3548,7 +3552,7 @@ module mpas_io_streams
 
 !call mpas_log_write('MGD calling MPAS_io_put_var now...')
             call MPAS_io_put_var(stream % fileHandle, field_cursor % real0dField % fieldName, real0d_temp, io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
          else if (field_cursor % field_type == FIELD_1D_REAL) then
@@ -3605,7 +3609,7 @@ module mpas_io_streams
                else
                   call MPAS_io_put_var(stream % fileHandle, field_cursor % real1dField % fieldName, real1d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
             end do
 
@@ -3668,7 +3672,7 @@ module mpas_io_streams
                else
                   call MPAS_io_put_var(stream % fileHandle, field_cursor % real2dField % fieldName, real2d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
             end do
 
@@ -3735,7 +3739,7 @@ module mpas_io_streams
                else
                   call MPAS_io_put_var(stream % fileHandle, field_cursor % real3dField % fieldName, real3d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
             end do
 
@@ -3804,7 +3808,7 @@ module mpas_io_streams
                else
                   call MPAS_io_put_var(stream % fileHandle, field_cursor % real4dField % fieldName, real4d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
             end do
 
@@ -3875,7 +3879,7 @@ module mpas_io_streams
                else
                   call MPAS_io_put_var(stream % fileHandle, field_cursor % real5dField % fieldName, real5d_temp, io_err)
                end if
-               call MPAS_io_err_mesg(io_err, .false.)
+               call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
                if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
             end do
 
@@ -3894,7 +3898,7 @@ module mpas_io_streams
 !call mpas_log_write('Copying field from first block')
 !call mpas_log_write('MGD calling MPAS_io_put_var now...')
             call MPAS_io_put_var(stream % fileHandle, field_cursor % char0dField % fieldName, field_cursor % char0dField % scalar, io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
          else if (field_cursor % field_type == FIELD_1D_CHAR) then
@@ -3906,7 +3910,7 @@ module mpas_io_streams
 !call mpas_log_write('Copying field from first block')
 !call mpas_log_write('MGD calling MPAS_io_put_var now...')
             call MPAS_io_put_var(stream % fileHandle, field_cursor % char1dField % fieldName, field_cursor % char1dField % array, io_err)
-            call MPAS_io_err_mesg(io_err, .false.)
+            call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
             if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
 
@@ -3945,7 +3949,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_get_att(stream % fileHandle, attName, attValue, ierr=io_err) 
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_readStreamAtt_0dInteger
@@ -3973,7 +3977,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_get_att(stream % fileHandle, attName, attValue, ierr=io_err) 
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_readStreamAtt_1dInteger
@@ -4009,7 +4013,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_get_att(stream % fileHandle, attName, attValue, precision=local_precision, ierr=io_err)
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_readStreamAtt_0dReal
@@ -4045,7 +4049,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_get_att(stream % fileHandle, attName, attValue, precision=local_precision, ierr=io_err)
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_readStreamAtt_1dReal
@@ -4073,7 +4077,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_get_att(stream % fileHandle, attName, attValue, ierr=io_err) 
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_readStreamAtt_text
@@ -4102,7 +4106,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, ierr=io_err) 
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_writeStreamAtt_0dInteger
@@ -4131,7 +4135,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, ierr=io_err) 
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_writeStreamAtt_1dInteger
@@ -4168,7 +4172,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, precision=local_precision, ierr=io_err)
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_writeStreamAtt_0dReal
@@ -4205,7 +4209,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, precision=local_precision, ierr=io_err)
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_writeStreamAtt_1dReal
@@ -4234,7 +4238,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_put_att(stream % fileHandle, attName, attValue, syncVal=syncVal, ierr=io_err) 
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
    end subroutine MPAS_writeStreamAtt_text
@@ -4261,7 +4265,7 @@ module mpas_io_streams
       end if
 
       call MPAS_io_close(stream % fileHandle, io_err)
-      call MPAS_io_err_mesg(io_err, .false.)
+      call MPAS_io_err_mesg(stream % fileHandle % ioContext, io_err, .false.)
       if (io_err /= MPAS_IO_NOERR .and. present(ierr)) ierr = MPAS_IO_ERR
 
 !call mpas_log_write('Deallocating global attribute list')

--- a/src/framework/mpas_io_types.inc
+++ b/src/framework/mpas_io_types.inc
@@ -1,7 +1,17 @@
+#ifdef MPAS_PIO_SUPPORT
 #ifdef USE_PIO2
    integer, parameter :: MPAS_IO_OFFSET_KIND = PIO_OFFSET_KIND
 #else
    integer, parameter :: MPAS_IO_OFFSET_KIND = PIO_OFFSET
+#endif
+
+#else
+
+#ifdef MPAS_SMIOL_SUPPORT
+   integer, parameter :: MPAS_IO_OFFSET_KIND = SMIOL_offset_kind
+#else
+   integer, parameter :: MPAS_IO_OFFSET_KIND = I8KIND
+#endif
 #endif
 
    ! File access modes
@@ -39,7 +49,7 @@
                          MPAS_IO_ERR_INVALID_FORMAT = -2, &
                          MPAS_IO_ERR_LONG_FILENAME  = -3, &
                          MPAS_IO_ERR_UNINIT_HANDLE  = -4, &
-                         MPAS_IO_ERR_PIO            = -5, &
+                         MPAS_IO_ERR_BACKEND        = -5, &
                          MPAS_IO_ERR_DATA_MODE      = -6, &
                          MPAS_IO_ERR_NOWRITE        = -7, &
                          MPAS_IO_ERR_REDEF_DIM      = -8, &
@@ -62,7 +72,12 @@
       logical :: preexisting_file = .false.
       logical :: data_mode = .false.
       logical :: external_file_desc = .false.
+#ifdef MPAS_PIO_SUPPORT
       type (file_desc_t) :: pio_file
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+      type (SMIOLf_file), pointer :: smiol_file => null()
+#endif
       character (len=StrKIND) :: filename
       integer :: iomode
       integer :: ioformat
@@ -82,7 +97,12 @@
       integer :: field_type
       integer, dimension(:), pointer :: dims
       integer, dimension(:), pointer :: indices
+#ifdef MPAS_PIO_SUPPORT
       type (io_desc_t) :: pio_iodesc
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+      type (SMIOLf_decomp), pointer :: smiol_decomp => null()
+#endif
    end type decomphandle_type
 
    type atthandle_type
@@ -106,7 +126,9 @@
    type fieldhandle_type
       character (len=StrKIND) :: fieldname
       integer :: fieldid
+#ifdef MPAS_PIO_SUPPORT
       type (Var_desc_t) :: field_desc
+#endif
       integer :: field_type
       logical :: has_unlimited_dim = .false.
       integer :: ndims
@@ -139,7 +161,12 @@
 
    type mpas_io_context_type
       type (decomplist_type), pointer :: decomp_list => null()
+#ifdef MPAS_PIO_SUPPORT
       type (iosystem_desc_t), pointer :: pio_iosystem => null()
+#endif
+#ifdef MPAS_SMIOL_SUPPORT
+      type (SMIOLf_context), pointer :: smiol_context => null()
+#endif
       integer :: master_pio_iotype = -999
       type (dm_info), pointer :: dminfo => null()
    end type mpas_io_context_type

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -3363,7 +3363,7 @@ module mpas_stream_manager
            !
            if ( .not. stream % blockWrite ) then
               STREAM_DEBUG_WRITE(' -- Prewrite reindex for stream ' // trim(stream % name))
-              call prewrite_reindex(manager % allFields, stream % field_pool)
+              call prewrite_reindex(manager % allFields, manager % allPackages, stream % field_pool, stream % field_pkg_pool)
            end if
 
            ! 
@@ -3973,12 +3973,13 @@ module mpas_stream_manager
            !
            ! Exchange halos for all decomposed fields in this stream
            !
-           call exch_all_halos(manager % allFields, stream % field_pool, stream % timeLevel, local_ierr)
+           call exch_all_halos(manager % allFields, manager % allPackages, stream % field_pool, stream % field_pkg_pool, &
+                               stream % timeLevel, local_ierr)
 
            !
            ! For any connectivity arrays in this stream, convert global indices to local indices
            !
-           call postread_reindex(manager % allFields, stream % field_pool)
+           call postread_reindex(manager % allFields, manager % allPackages, stream % field_pool, stream % field_pkg_pool)
         end if
 
     end subroutine read_stream !}}}
@@ -4646,12 +4647,14 @@ module mpas_stream_manager
     !>  This routine performs a halo exchange of each decomposed field within a stream.
     !
     !-----------------------------------------------------------------------
-    subroutine exch_all_halos(allFields, streamFields, timeLevel, ierr) !{{{
+    subroutine exch_all_halos(allFields, allPackages, streamFields, fieldPkgPool, timeLevel, ierr) !{{{
 
         implicit none
 
         type (mpas_pool_type), pointer :: allFields
+        type (mpas_pool_type), pointer :: allPackages
         type (mpas_pool_type), pointer :: streamFields
+        type (mpas_pool_type), pointer :: fieldPkgPool
         integer, intent(in) :: timeLevel
         integer, intent(out) :: ierr
 
@@ -4667,6 +4670,10 @@ module mpas_stream_manager
         type (field2DInteger), pointer :: int2DField
         type (field3DInteger), pointer :: int3DField
 
+        character (len=StrKIND), pointer :: packages
+        logical :: active_field
+        integer :: err_level
+
 
         ierr = MPAS_STREAM_MGR_NOERR
 
@@ -4676,6 +4683,26 @@ module mpas_stream_manager
 
             ! Note: in a stream's field_pool, the names of fields are stored as configs
             if ( fieldItr % memberType == MPAS_POOL_CONFIG ) then
+
+                !
+                ! Check whether the field is active in this stream
+                !
+                err_level = mpas_pool_get_error_level()
+                call mpas_pool_set_error_level(MPAS_POOL_SILENT)
+
+                nullify(packages)
+                call mpas_pool_get_config(fieldPkgPool, trim(fieldItr % memberName)//':packages', packages)
+                if (associated(packages)) then
+                    active_field = parse_package_list(allPackages, trim(packages))
+                else
+                    active_field = .true.
+                end if
+                call mpas_pool_set_error_level(err_level)
+
+                if (.not. active_field) then
+                    STREAM_DEBUG_WRITE('-- '//trim(fieldItr % memberName)//' not active in stream and halo will not be exchanged')
+                    cycle
+                end if
 
                 call mpas_pool_get_field_info(allFields, fieldItr % memberName, fieldInfo)
 
@@ -4837,7 +4864,7 @@ module mpas_stream_manager
     !>                  the top of this module where this routine is made public.
     !
     !-----------------------------------------------------------------------
-    subroutine prewrite_reindex(allFields, streamFields) !{{{
+    subroutine prewrite_reindex(allFields, allPackages, streamFields, fieldPkgPool) !{{{
 
         implicit none
 
@@ -4846,7 +4873,9 @@ module mpas_stream_manager
         integer, parameter :: UNUSED_VERTEX = 0
 
         type (mpas_pool_type), pointer :: allFields
+        type (mpas_pool_type), pointer :: allPackages
         type (mpas_pool_type), pointer :: streamFields
+        type (mpas_pool_type), pointer :: fieldPkgPool
 
         type (mpas_pool_iterator_type) :: fieldItr
         type (mpas_pool_field_info_type) :: fieldInfo
@@ -4868,6 +4897,11 @@ module mpas_stream_manager
                    handle_edgesOnEdge, handle_cellsOnVertex, handle_edgesOnVertex
 
         integer :: i, j, threadNum
+
+        character (len=StrKIND), pointer :: packages
+        logical :: active_field
+        integer :: err_level
+
 
         threadNum = mpas_threading_get_thread_num()
 
@@ -4898,6 +4932,27 @@ module mpas_stream_manager
 
                ! Note: in a stream's field_pool, the names of fields are stored as configs
                if ( fieldItr % memberType == MPAS_POOL_CONFIG ) then
+
+                   !
+                   ! Check whether the field is active in this stream
+                   !
+                   err_level = mpas_pool_get_error_level()
+                   call mpas_pool_set_error_level(MPAS_POOL_SILENT)
+
+                   nullify(packages)
+                   call mpas_pool_get_config(fieldPkgPool, trim(fieldItr % memberName)//':packages', packages)
+                   if (associated(packages)) then
+                       active_field = parse_package_list(allPackages, trim(packages))
+                   else
+                       active_field = .true.
+                   end if
+                   call mpas_pool_set_error_level(err_level)
+
+                   if (.not. active_field) then
+                       STREAM_DEBUG_WRITE('-- '//trim(fieldItr % memberName)//' not active in stream and will not be reindexed')
+                       cycle
+                   end if
+
                    call mpas_pool_get_field_info(allFields, fieldItr % memberName, fieldInfo)
 
                    if (trim(fieldItr % memberName) == 'cellsOnCell') then
@@ -4959,6 +5014,7 @@ module mpas_stream_manager
                call mpas_pool_get_dimension(indexToCellID % block % dimensions, 'vertexDegree', vertexDegree)
 
                if (associated(cellsOnCell)) then
+                   STREAM_DEBUG_WRITE('  -- reindexing cellsOnCell from local to global indices')
                    cellsOnCell_ptr % array => cellsOnCell % array
                    allocate(cellsOnCell % array(maxEdges, nCells+1))
 
@@ -4979,6 +5035,7 @@ module mpas_stream_manager
                end if
 
                if (associated(edgesOnCell)) then
+                   STREAM_DEBUG_WRITE('  -- reindexing edgesOnCell from local to global indices')
                    edgesOnCell_ptr % array => edgesOnCell % array
                    allocate(edgesOnCell % array(maxEdges, nCells+1))
 
@@ -4999,6 +5056,7 @@ module mpas_stream_manager
                end if
 
                if (associated(verticesOnCell)) then
+                   STREAM_DEBUG_WRITE('  -- reindexing verticesOnCell from local to global indices')
                    verticesOnCell_ptr % array => verticesOnCell % array
                    allocate(verticesOnCell % array(maxEdges, nCells+1))
 
@@ -5019,6 +5077,7 @@ module mpas_stream_manager
                end if
 
                if (associated(cellsOnEdge)) then
+                   STREAM_DEBUG_WRITE('  -- reindexing cellsOnEdge from local to global indices')
                    cellsOnEdge_ptr % array => cellsOnEdge % array
                    allocate(cellsOnEdge % array(2, nEdges+1))
 
@@ -5036,6 +5095,7 @@ module mpas_stream_manager
                end if
 
                if (associated(verticesOnEdge)) then
+                   STREAM_DEBUG_WRITE('  -- reindexing verticesOnEdge from local to global indices')
                    verticesOnEdge_ptr % array => verticesOnEdge % array
                    allocate(verticesOnEdge % array(2, nEdges+1))
 
@@ -5053,6 +5113,7 @@ module mpas_stream_manager
                end if
 
                if (associated(edgesOnEdge)) then
+                   STREAM_DEBUG_WRITE('  -- reindexing edgesOnEdge from local to global indices')
                    edgesOnEdge_ptr % array => edgesOnEdge % array
                    allocate(edgesOnEdge % array(maxEdges2, nEdges+1))
 
@@ -5073,6 +5134,7 @@ module mpas_stream_manager
                end if
 
                if (associated(cellsOnVertex)) then
+                   STREAM_DEBUG_WRITE('  -- reindexing cellsOnVertex from local to global indices')
                    cellsOnVertex_ptr % array => cellsOnVertex % array
                    allocate(cellsOnVertex % array(vertexDegree, nVertices+1))
 
@@ -5091,6 +5153,7 @@ module mpas_stream_manager
                end if
 
                if (associated(edgesOnVertex)) then
+                   STREAM_DEBUG_WRITE('  -- reindexing edgesOnVertex from local to global indices')
                    edgesOnVertex_ptr % array => edgesOnVertex % array
                    allocate(edgesOnVertex % array(vertexDegree, nVertices+1))
 
@@ -5211,6 +5274,7 @@ module mpas_stream_manager
            do while (associated(indexToCellID))
 
                if (associated(cellsOnCell)) then
+                   STREAM_DEBUG_WRITE('  -- restoring cellsOnCell to local indices')
                    deallocate(cellsOnCell % array)
                    cellsOnCell % array => cellsOnCell_ptr % array
                    nullify(cellsOnCell_ptr % array)
@@ -5219,6 +5283,7 @@ module mpas_stream_manager
                end if
 
                if (associated(edgesOnCell)) then
+                   STREAM_DEBUG_WRITE('  -- restoring edgesOnCell to local indices')
                    deallocate(edgesOnCell % array)
                    edgesOnCell % array => edgesOnCell_ptr % array
                    nullify(edgesOnCell_ptr % array)
@@ -5227,6 +5292,7 @@ module mpas_stream_manager
                end if
 
                if (associated(verticesOnCell)) then
+                   STREAM_DEBUG_WRITE('  -- restoring verticesOnCell to local indices')
                    deallocate(verticesOnCell % array)
                    verticesOnCell % array => verticesOnCell_ptr % array
                    nullify(verticesOnCell_ptr % array)
@@ -5235,6 +5301,7 @@ module mpas_stream_manager
                end if
 
                if (associated(cellsOnEdge)) then
+                   STREAM_DEBUG_WRITE('  -- restoring cellsOnEdge to local indices')
                    deallocate(cellsOnEdge % array)
                    cellsOnEdge % array => cellsOnEdge_ptr % array
                    nullify(cellsOnEdge_ptr % array)
@@ -5243,6 +5310,7 @@ module mpas_stream_manager
                end if
 
                if (associated(verticesOnEdge)) then
+                   STREAM_DEBUG_WRITE('  -- restoring verticesOnEdge to local indices')
                    deallocate(verticesOnEdge % array)
                    verticesOnEdge % array => verticesOnEdge_ptr % array
                    nullify(verticesOnEdge_ptr % array)
@@ -5251,6 +5319,7 @@ module mpas_stream_manager
                end if
 
                if (associated(edgesOnEdge)) then
+                   STREAM_DEBUG_WRITE('  -- restoring edgesOnEdge to local indices')
                    deallocate(edgesOnEdge % array)
                    edgesOnEdge % array => edgesOnEdge_ptr % array
                    nullify(edgesOnEdge_ptr % array)
@@ -5259,6 +5328,7 @@ module mpas_stream_manager
                end if
 
                if (associated(cellsOnVertex)) then
+                   STREAM_DEBUG_WRITE('  -- restoring cellsOnVertex to local indices')
                    deallocate(cellsOnVertex % array)
                    cellsOnVertex % array => cellsOnVertex_ptr % array
                    nullify(cellsOnVertex_ptr % array)
@@ -5267,6 +5337,7 @@ module mpas_stream_manager
                end if
 
                if (associated(edgesOnVertex)) then
+                   STREAM_DEBUG_WRITE('  -- restoring edgesOnVertex to local indices')
                    deallocate(edgesOnVertex % array)
                    edgesOnVertex % array => edgesOnVertex_ptr % array
                    nullify(edgesOnVertex_ptr % array)
@@ -5312,12 +5383,14 @@ module mpas_stream_manager
     !>  This routine should be called immediately after a read of a stream.
     !
     !-----------------------------------------------------------------------
-    subroutine postread_reindex(allFields, streamFields) !{{{
+    subroutine postread_reindex(allFields, allPackages, streamFields, fieldPkgPool) !{{{
 
         implicit none
 
         type (mpas_pool_type), pointer :: allFields
+        type (mpas_pool_type), pointer :: allPackages
         type (mpas_pool_type), pointer :: streamFields
+        type (mpas_pool_type), pointer :: fieldPkgPool
 
         type (mpas_pool_iterator_type) :: fieldItr
         type (mpas_pool_field_info_type) :: fieldInfo
@@ -5332,6 +5405,10 @@ module mpas_stream_manager
         logical :: skip_field
         integer :: i, j, k
 
+        character (len=StrKIND), pointer :: packages
+        logical :: active_field
+        integer :: err_level
+
 
         call mpas_pool_get_field(allFields, 'indexToCellID', indexToCellID)
         call mpas_pool_get_field(allFields, 'indexToEdgeID', indexToEdgeID)
@@ -5344,12 +5421,32 @@ module mpas_stream_manager
             ! Note: in a stream's field_pool, the names of fields are stored as configs
             if ( fieldItr % memberType == MPAS_POOL_CONFIG ) then
 
+                !
+                ! Check whether the field is active in this stream
+                !
+                err_level = mpas_pool_get_error_level()
+                call mpas_pool_set_error_level(MPAS_POOL_SILENT)
+
+                nullify(packages)
+                call mpas_pool_get_config(fieldPkgPool, trim(fieldItr % memberName)//':packages', packages)
+                if (associated(packages)) then
+                    active_field = parse_package_list(allPackages, trim(packages))
+                else
+                    active_field = .true.
+                end if
+                call mpas_pool_set_error_level(err_level)
+
+                if (.not. active_field) then
+                    STREAM_DEBUG_WRITE('-- '//trim(fieldItr % memberName)//' not active in stream and will not be reindexed')
+                    cycle
+                end if
+
                 call mpas_pool_get_field_info(allFields, fieldItr % memberName, fieldInfo)
 
                 skip_field = .false.
                 if (trim(fieldItr % memberName) == 'cellsOnCell') then
 
-                    STREAM_DEBUG_WRITE('-- Reindexing cellsOnCell')
+                    STREAM_DEBUG_WRITE(' -- Reindexing cellsOnCell')
 
                     ! Get pointer to the field to be reindexed
                     call mpas_pool_get_field(allFields, 'cellsOnCell', int2DField)
@@ -5365,7 +5462,7 @@ module mpas_stream_manager
 
                 else if (trim(fieldItr % memberName) == 'edgesOnCell') then
 
-                    STREAM_DEBUG_WRITE('-- Reindexing edgesOnCell')
+                    STREAM_DEBUG_WRITE(' -- Reindexing edgesOnCell')
 
                     ! Get pointer to the field to be reindexed
                     call mpas_pool_get_field(allFields, 'edgesOnCell', int2DField)
@@ -5381,7 +5478,7 @@ module mpas_stream_manager
 
                 else if (trim(fieldItr % memberName) == 'verticesOnCell') then
 
-                    STREAM_DEBUG_WRITE('-- Reindexing verticesOnCell')
+                    STREAM_DEBUG_WRITE(' -- Reindexing verticesOnCell')
 
                     ! Get pointer to the field to be reindexed
                     call mpas_pool_get_field(allFields, 'verticesOnCell', int2DField)
@@ -5397,7 +5494,7 @@ module mpas_stream_manager
 
                 else if (trim(fieldItr % memberName) == 'cellsOnEdge') then
 
-                    STREAM_DEBUG_WRITE('-- Reindexing cellsOnEdge')
+                    STREAM_DEBUG_WRITE(' -- Reindexing cellsOnEdge')
 
                     ! Get pointer to the field to be reindexed
                     call mpas_pool_get_field(allFields, 'cellsOnEdge', int2DField)
@@ -5413,7 +5510,7 @@ module mpas_stream_manager
 
                 else if (trim(fieldItr % memberName) == 'verticesOnEdge') then
 
-                    STREAM_DEBUG_WRITE('-- Reindexing verticesOnEdge')
+                    STREAM_DEBUG_WRITE(' -- Reindexing verticesOnEdge')
 
                     ! Get pointer to the field to be reindexed
                     call mpas_pool_get_field(allFields, 'verticesOnEdge', int2DField)
@@ -5429,7 +5526,7 @@ module mpas_stream_manager
 
                 else if (trim(fieldItr % memberName) == 'edgesOnEdge') then
 
-                    STREAM_DEBUG_WRITE('-- Reindexing edgesOnEdge')
+                    STREAM_DEBUG_WRITE(' -- Reindexing edgesOnEdge')
 
                     ! Get pointer to the field to be reindexed
                     call mpas_pool_get_field(allFields, 'edgesOnEdge', int2DField)
@@ -5445,7 +5542,7 @@ module mpas_stream_manager
 
                 else if (trim(fieldItr % memberName) == 'cellsOnVertex') then
 
-                    STREAM_DEBUG_WRITE('-- Reindexing cellsOnVertex')
+                    STREAM_DEBUG_WRITE(' -- Reindexing cellsOnVertex')
 
                     ! Get pointer to the field to be reindexed
                     call mpas_pool_get_field(allFields, 'cellsOnVertex', int2DField)
@@ -5461,7 +5558,7 @@ module mpas_stream_manager
 
                 else if (trim(fieldItr % memberName) == 'edgesOnVertex') then
 
-                    STREAM_DEBUG_WRITE('-- Reindexing edgesOnVertex')
+                    STREAM_DEBUG_WRITE(' -- Reindexing edgesOnVertex')
 
                     ! Get pointer to the field to be reindexed
                     call mpas_pool_get_field(allFields, 'edgesOnVertex', int2DField)

--- a/src/framework/mpas_string_utils.F
+++ b/src/framework/mpas_string_utils.F
@@ -1,3 +1,4 @@
+! Copyright (c) 2023 The University Corporation for Atmospheric Research (UCAR).
 !
 ! Unless noted otherwise source code is licensed under the BSD license.
 ! Additional copyright and license information can be found in the LICENSE file

--- a/src/framework/mpas_string_utils.F
+++ b/src/framework/mpas_string_utils.F
@@ -1,0 +1,104 @@
+!
+! Unless noted otherwise source code is licensed under the BSD license.
+! Additional copyright and license information can be found in the LICENSE file
+! distributed with this code, or at https://mpas-dev.github.io/license.html .
+!
+!-----------------------------------------------------------------------
+!  mpas_string_utils
+!
+!> \brief Collection of functions used for string manipulation
+!> \author Matthew Dimond
+!> \date   25 July 2023
+!> \details
+!>  This module provides functions and subroutines used for string
+!>  manipulations and utilities.
+!
+!-----------------------------------------------------------------------
+module mpas_string_utils
+
+    contains
+
+    !-----------------------------------------------------------------------
+    !  routine mpas_split_string
+    !
+    !> \brief This routine splits a string on a specified delimiting character
+    !> \author Michael Duda, Doug Jacobsen
+    !> \date   07/23/2014
+    !> \details This routine splits the given "string" on the delimiter
+    !>          character, and returns an array of pointers to the substrings
+    !>          between the delimiting characters. Strings are trimmed before
+    !>          splitting such that all trailing whitespace is ignored.
+    !
+    !-----------------------------------------------------------------------
+    subroutine mpas_split_string(string, delimiter, subStrings)
+
+        implicit none
+
+        ! Arguments
+        character(len=*), intent(in) :: string
+        character, intent(in) :: delimiter
+        character(len=*), pointer, dimension(:) :: subStrings
+
+        ! Local variables
+        character(len=len_trim(string)) :: trimString
+        integer :: i, start, index
+
+        trimString = trim(string)
+        index = 1
+
+        do i = 1, len(trimString)
+            if (trimString(i:i) == delimiter) then
+                index = index + 1
+            end if
+        end do
+
+        allocate(subStrings(1:index))
+
+        start = 1
+        index = 1
+        do i = 1, len(trimString)
+            if (trimString(i:i) == delimiter) then
+                subStrings(index) = trimString(start:i-1)
+                index = index + 1
+                start = i + 1
+            end if
+        end do
+        subStrings(index) = trimString(start:len(trimString))
+
+    end subroutine mpas_split_string
+
+    !-----------------------------------------------------------------------
+    !  routine mpas_string_replace
+    !
+    !> \brief Returns string with charToReplace replaced with targetChar
+    !> \author Matthew Dimond
+    !> \date   07/26/2023
+    !> \details This function replaces all characters matching charToReplace in
+    !>          "string" with the char "targetChar" after trimming "string"
+    !
+    !-----------------------------------------------------------------------
+    function mpas_string_replace(string, charToReplace, targetChar) result(stringOut)
+
+        implicit none
+
+        ! Arguments
+        character(len=*), intent(in) :: string 
+        character, intent(in) :: targetChar, charToReplace
+
+        ! Local variables
+        integer :: i
+
+        ! Result
+        character(len=len_trim(string)) :: stringOut
+
+        stringOut = trim(string)
+
+        do i = 1, len_trim(string)
+            if (string(i:i) == charToReplace) then
+                stringOut(i:i) = targetChar
+            end if
+        end do
+
+    end function mpas_string_replace
+
+end module mpas_string_utils

--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -12,6 +12,7 @@ module mpas_timekeeping
    use mpas_dmpar
    use mpas_threading
    use mpas_log
+   use mpas_string_utils, only : mpas_split_string
 
    use ESMF
 
@@ -2107,40 +2108,6 @@ module mpas_timekeeping
 !      mod % ti = mod(ti1 % ti, ti2 % ti)
 !
 !   end function mod
-
-
-   subroutine mpas_split_string(string, delimiter, subStrings)   
-      
-      implicit none
-      
-      character(len=*), intent(in) :: string
-      character, intent(in) :: delimiter
-      character(len=*), pointer, dimension(:) :: subStrings
-      
-      integer :: i, start, index
-
-      index = 1
-      do i = 1, len(string)
-         if(string(i:i) == delimiter) then
-            index = index + 1
-         end if
-      end do
-
-      allocate(subStrings(1:index))
-
-      start = 1
-      index = 1
-      do i = 1, len(string)
-         if(string(i:i) == delimiter) then
-               subStrings(index) = string(start:i-1) 
-               index = index + 1
-               start = i + 1
-         end if
-      end do
-      subStrings(index) = string(start:len(string)) 
-      
-   end subroutine mpas_split_string
-
 
     subroutine mpas_get_month_day(YYYY, DoY, month, day)
        


### PR DESCRIPTION
Catch up to MPAS-A v8.0.1 framework changes that were introduced as part of [EarthWorksOrg/EarthWorks PR#22](https://github.com/EarthWorksOrg/EarthWorks/pull/22).