### PR TITLE
Update/ocean3p75

### DIFF
--- a/src/framework-sed/mpas_derived_types.F
+++ b/src/framework-sed/mpas_derived_types.F
@@ -30,7 +30,11 @@ module MPASAOS_derived_types
    use pio
    use pio_types
 
+#ifdef DATMFORCEDRESTORING
+   use ESMFloc
+#else
    use ESMF
+#endif
 
 #include "mpas_attlist_types.inc"
 

--- a/src/framework-sed/mpas_derived_types.F
+++ b/src/framework-sed/mpas_derived_types.F
@@ -30,11 +30,7 @@ module MPASAOS_derived_types
    use pio
    use pio_types
 
-#ifdef DATMFORCEDRESTORING
    use ESMFloc
-#else
-   use ESMF
-#endif
 
 #include "mpas_attlist_types.inc"
 

--- a/src/framework-sed/mpas_forcing.F
+++ b/src/framework-sed/mpas_forcing.F
@@ -922,7 +922,7 @@ contains
        forcingGroupName, &
        streamManager, &
        restart, &
-       interpolateAtInit)
+       interpolateAtInit, whence )
 
     type(mpas_forcing_group_type), pointer :: &
          forcingGroupHead ! the forcing group linked list
@@ -939,11 +939,23 @@ contains
     logical, intent(in) :: &
          interpolateAtInit !< Input: interpolate to forcing variables at time 0.
 
+    integer, intent(in), optional :: &
+         whence !< Input: optionally read stream at other than mpas_stream_exact_time
+
     type(mpas_forcing_group_type), pointer :: &
          forcingGroup ! forcing group iterator
 
     type(mpas_forcing_stream_type), pointer :: &
          forcingStream ! forcing stream iterator
+
+    ! local variables
+    integer :: whenceloc
+
+    if(present(whence)) then
+       whenceloc = whence
+    else
+       whenceloc = mpas_stream_exact_time
+    endif
 
     ! loop over forcings linked list
     forcingGroup => forcingGroupHead
@@ -960,7 +972,8 @@ contains
                   forcingStream, &
                   streamManager, &
                   restart, &
-                  interpolateAtInit)
+                  interpolateAtInit, &
+                  whenceloc )
 
              forcingStream => forcingStream % next
           end do
@@ -990,7 +1003,8 @@ contains
        forcingStream, &
        streamManager, &
        restart, &
-       interpolateAtInit)
+       interpolateAtInit, &
+       whenceloc )
 
     type(mpas_forcing_group_type), pointer :: &
          forcingGroup ! the forcing group object
@@ -1006,6 +1020,9 @@ contains
 
     logical, intent(in) :: &
          interpolateAtInit !< Input: interpolate to forcing variables at time 0.
+
+    integer, intent(in), optional :: &
+         whenceloc !< Input: optionally read stream at other than mpas_stream_exact_time
 
     type(MPAS_Time_type) :: &
          forcingTimeCycle, & ! the forcing time after cycling
@@ -1111,14 +1128,25 @@ contains
        ! load the data into the slot
        call mpas_get_time(forcingTimeCycle, dateTimeString=forcingTimeStr)
        FORCING_DEBUG_WRITE('-- Forcing: get_initial_forcing_data: READ ATTEMPT: '//trim(forcingTimeStr))
-       call MPAS_stream_mgr_read(&
-            streamManager, &
-            forcingStream % forcingStreamID, &
-            timeLevel=iTime, &
-            when=forcingTimeStr, &
-            whence=MPAS_STREAM_EXACT_TIME, &
-            rightNow=.true., &
-            ierr=ierr)
+       if(present(whenceloc)) then
+          call MPAS_stream_mgr_read(&
+               streamManager, &
+               forcingStream % forcingStreamID, &
+               timeLevel=iTime, &
+               when=forcingTimeStr, &
+               whence=whenceloc, &
+               rightNow=.true., &
+               ierr=ierr)
+       else
+          call MPAS_stream_mgr_read(&
+               streamManager, &
+               forcingStream % forcingStreamID, &
+               timeLevel=iTime, &
+               when=forcingTimeStr, &
+               whence=MPAS_STREAM_EXACT_TIME, &
+               rightNow=.true., &
+               ierr=ierr)
+       endif
 
        if (ierr /= 0) then
           call mpas_log_write('Forcing: get_initial_forcing_data: READ: $i', MPAS_LOG_CRIT, intArgs=(/ierr/))
@@ -1288,6 +1316,8 @@ contains
     type(mpas_forcing_stream_type), pointer :: &
          forcingStream
 
+    integer :: ierr 
+
     ! check if cycling alarm is ringing
     if (mpas_is_alarm_ringing(forcingGroup % forcingClock, forcingGroup % forcingCycleAlarmID)) then
 
@@ -1295,8 +1325,9 @@ contains
 
        ! if ringing cycle the clock
        oldForingClockTime = mpas_get_clock_time(forcingGroup % forcingClock, MPAS_NOW)
+
        newForcingClockTime = oldForingClockTime - forcingGroup % forcingCycleDuration
-       call mpas_set_clock_time(forcingGroup % forcingClock, newForcingClockTime, MPAS_NOW)
+       call mpas_set_clock_time(forcingGroup % forcingClock, newForcingClockTime, MPAS_NOW, ierr=ierr)
 
        ! if ringing cycle the forcing times
        forcingStream => forcingGroup % stream

--- a/src/framework-sed/mpas_stream_manager.F
+++ b/src/framework-sed/mpas_stream_manager.F
@@ -3836,8 +3836,9 @@ module MPASAOS_stream_manager
            else if (stream % nRecords /= 0) then
                STREAM_DEBUG_WRITE('   Seeked record is: $i out of $i with a time stamp of ' // trim(temp_actualWhen) // ' filename was ' // trim(stream % filename) COMMA intArgs=(/stream%nRecords COMMA temp_maxRecords/))
            else if (temp_maxRecords /= 0 .and. whence == MPAS_STREAM_EXACT_TIME) then
-               STREAM_ERROR_WRITE('File ' // trim(stream % filename) // ' does not contain the time ' // trim(when))
-               ierr = MPAS_STREAM_MGR_ERROR
+               !STREAM_ERROR_WRITE('File ' // trim(stream % filename) // ' does not contain the time ' // trim(when))
+               !ierr = MPAS_STREAM_MGR_ERROR
+               STREAM_WARNING_WRITE('File ' // trim(stream % filename) // ' does not contain the time ' // trim(when))
                return
            end if
 

--- a/src/framework-sed/mpas_timekeeping.F
+++ b/src/framework-sed/mpas_timekeeping.F
@@ -13,7 +13,11 @@ module MPASAOS_timekeeping
    use MPASAOS_threading
    use MPASAOS_log
 
+#ifdef DATMFORCEDRESTORING
+   use ESMFloc
+#else
    use ESMF
+#endif
 
    private :: mpas_calibrate_alarms
    private :: mpas_in_ringing_envelope
@@ -91,32 +95,45 @@ module MPASAOS_timekeeping
 
       if (trim(calendar) == 'gregorian') then
          TheCalendar = MPAS_GREGORIAN
-#ifndef MPAS_NO_ESMF_INIT
-#ifndef MPAS_EXTERNAL_ESMF_LIB
-         call ESMF_Initialize(defaultCalendar=ESMF_CALKIND_GREGORIAN)
-#else
-         call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_GREGORIAN)
-#endif
-#endif
+
+#ifdef DATMFORCEDRESTORING
+
+         call ESMFloc_Initialize(defaultCalendar=ESMFloc_CALKIND_GREGORIAN)
       else if (trim(calendar) == 'noleap') then
          TheCalendar = MPAS_GREGORIAN_NOLEAP
-#ifndef MPAS_NO_ESMF_INIT
-#ifndef MPAS_EXTERNAL_ESMF_LIB
-         call ESMF_Initialize(defaultCalendar=ESMF_CALKIND_NOLEAP)
+         call ESMFloc_Initialize(defaultCalendar=ESMFloc_CALKIND_NOLEAP)
+
 #else
-         call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_NOLEAP)
-#endif
-#endif
+
+    #ifndef MPAS_NO_ESMF_INIT
+        #ifndef MPAS_EXTERNAL_ESMF_LIB
+            call ESMF_Initialize(defaultCalendar=ESMF_CALKIND_GREGORIAN)
+        #else
+            call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_GREGORIAN)
+        #endif
+    #endif
+    else if (trim(calendar) == 'noleap') then
+         TheCalendar = MPAS_GREGORIAN_NOLEAP
+    #ifndef MPAS_NO_ESMF_INIT
+        #ifndef MPAS_EXTERNAL_ESMF_LIB
+             call ESMF_Initialize(defaultCalendar=ESMF_CALKIND_NOLEAP)
+        #else
+             call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_NOLEAP)
+        #endif
+    #endif
       else if (trim(calendar) == '360day') then
         TheCalendar = MPAS_360DAY
-#ifndef MPAS_NO_ESMF_INIT
-#ifndef MPAS_EXTERNAL_ESMF_LIB
-!        call ESMF_Initialize(defaultCalendar=ESMF_CALKIND_360DAY)
-         call mpas_log_write('mpas_timekeeping_init: 360-day calendar not supported with the built-in ESMF timekeeping library', MPAS_LOG_ERR)
-#else
-         call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_360DAY)
+    #ifndef MPAS_NO_ESMF_INIT
+        #ifndef MPAS_EXTERNAL_ESMF_LIB
+        !    call ESMF_Initialize(defaultCalendar=ESMF_CALKIND_360DAY)
+             call mpas_log_write('mpas_timekeeping_init: 360-day calendar not supported with the built-in ESMF timekeeping library', MPAS_LOG_ERR)
+        #else
+             call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_360DAY)
+        #endif
+    #endif
+
 #endif
-#endif
+
       else
          call mpas_log_write('mpas_timekeeping_init: Invalid calendar type', MPAS_LOG_ERR)
       end if
@@ -130,8 +147,10 @@ module MPASAOS_timekeeping
 
       implicit none
 
-#ifndef MPAS_NO_ESMF_INIT
-      call ESMF_Finalize()
+#ifndef DATMFORCEDRESTORING
+    #ifndef MPAS_NO_ESMF_INIT
+        call ESMF_Finalize()
+    #endif
 #endif
 
    end subroutine mpas_timekeeping_finalize
@@ -165,8 +184,12 @@ module MPASAOS_timekeeping
      ! though this may not be a problem, since the library appears to return time strings
      ! with as many digits as are needed to represent the year.
      !
-#ifndef MPAS_EXTERNAL_ESMF_LIB
-      call ESMF_setYearWidth(yearWidthIn)
+#ifdef DATMFORCEDRESTORING
+        call ESMFloc_setYearWidth(yearWidthIn)
+#else
+    #ifndef MPAS_EXTERNAL_ESMF_LIB
+        call ESMF_setYearWidth(yearWidthIn)
+    #endif
 #endif
 
    end subroutine mpas_timekeeping_set_year_width!}}}
@@ -205,10 +228,17 @@ module MPASAOS_timekeeping
             return
          end if
 
+#ifdef DATMFORCEDRESTORING
+         clock % c = ESMFloc_ClockCreate(TimeStep=timeStep%ti, StartTime=startTime%t, StopTime=stop_time%t, rc=ierr)
+         if (present(ierr)) then
+            if (ierr == ESMFloc_SUCCESS) ierr = 0
+         end if
+#else
          clock % c = ESMF_ClockCreate(TimeStep=timeStep%ti, StartTime=startTime%t, StopTime=stop_time%t, rc=ierr)
          if (present(ierr)) then
             if (ierr == ESMF_SUCCESS) ierr = 0
          end if
+#endif
          clock % direction = MPAS_FORWARD
          clock % nAlarms = 0
          nullify(clock % alarmListHead)
@@ -239,10 +269,17 @@ module MPASAOS_timekeeping
             alarmPtr => clock % alarmListHead
          end do
 
+#ifdef DATMFORCEDRESTORING
+         call ESMFloc_ClockDestroy(clock % c, rc=ierr)
+         if (present(ierr)) then
+            if (ierr == ESMFloc_SUCCESS) ierr = 0
+         end if
+#else
          call ESMF_ClockDestroy(clock % c, rc=ierr)
          if (present(ierr)) then
             if (ierr == ESMF_SUCCESS) ierr = 0
          end if
+#endif
       end if
 
       !$omp barrier
@@ -257,6 +294,16 @@ module MPASAOS_timekeeping
       type (MPAS_Clock_type), intent(in) :: clock
       integer, intent(out), optional :: ierr
 
+#ifdef DATMFORCEDRESTORING
+      type (ESMFloc_Time) :: currTime, startTime, stopTime
+
+      call ESMFloc_ClockGet(clock % c, CurrTime=currTime, rc=ierr)
+      call ESMFloc_ClockGet(clock % c, StartTime=startTime, rc=ierr)
+      call ESMFloc_ClockGet(clock % c, StopTime=stopTime, rc=ierr)
+      if (present(ierr)) then
+         if (ierr == ESMFloc_SUCCESS) ierr = 0
+      end if
+#else
       type (ESMF_Time) :: currTime, startTime, stopTime
 
       call ESMF_ClockGet(clock % c, CurrTime=currTime, rc=ierr)
@@ -265,6 +312,7 @@ module MPASAOS_timekeeping
       if (present(ierr)) then
          if (ierr == ESMF_SUCCESS) ierr = 0
       end if
+#endif
 
       if (startTime <= stopTime) then
          mpas_is_clock_start_time = (currTime <= startTime)
@@ -282,6 +330,16 @@ module MPASAOS_timekeeping
       type (MPAS_Clock_type), intent(in) :: clock
       integer, intent(out), optional :: ierr
 
+#ifdef DATMFORCEDRESTORING
+      type (ESMFloc_Time) :: currTime, startTime, stopTime
+
+      call ESMFloc_ClockGet(clock % c, CurrTime=currTime, rc=ierr)
+      call ESMFloc_ClockGet(clock % c, StartTime=startTime, rc=ierr)
+      call ESMFloc_ClockGet(clock % c, StopTime=stopTime, rc=ierr)
+      if (present(ierr)) then
+         if (ierr == ESMFloc_SUCCESS) ierr = 0
+      end if
+#else
       type (ESMF_Time) :: currTime, startTime, stopTime
 
       call ESMF_ClockGet(clock % c, CurrTime=currTime, rc=ierr)
@@ -290,6 +348,7 @@ module MPASAOS_timekeeping
       if (present(ierr)) then
          if (ierr == ESMF_SUCCESS) ierr = 0
       end if
+#endif
 
       if (startTime <= stopTime) then
          mpas_is_clock_stop_time = (currTime >= stopTime)
@@ -318,15 +377,25 @@ module MPASAOS_timekeeping
 
       if ( threadNum == 0 ) then
          clock % direction = direction
+#ifdef DATMFORCEDRESTORING
+         call ESMFloc_ClockGet(clock % c, TimeStep=timeStep%ti, rc=ierr)
+         timeStep = neg_ti(timeStep)
+         call ESMFloc_ClockSet(clock % c, TimeStep=timeStep%ti, rc=ierr)
+#else
          call ESMF_ClockGet(clock % c, TimeStep=timeStep%ti, rc=ierr)
          timeStep = neg_ti(timeStep)
          call ESMF_ClockSet(clock % c, TimeStep=timeStep%ti, rc=ierr)
+#endif
 
          ! specify a valid previousRingTime for each alarm
          call mpas_calibrate_alarms(clock, ierr);
 
          if (present(ierr)) then
+#ifdef DATMFORCEDRESTORING
+            if (ierr == ESMFloc_SUCCESS) ierr = 0
+#else
             if (ierr == ESMF_SUCCESS) ierr = 0
+#endif
          end if
       end if
 
@@ -362,10 +431,17 @@ module MPASAOS_timekeeping
       threadNum = mpas_threading_get_thread_num()
 
       if ( threadNum == 0 ) then
+#ifdef DATMFORCEDRESTORING
+         call ESMFloc_ClockSet(clock % c, TimeStep=timeStep%ti, rc=ierr)
+         if (present(ierr)) then
+            if (ierr == ESMFloc_SUCCESS) ierr = 0
+         end if
+#else
          call ESMF_ClockSet(clock % c, TimeStep=timeStep%ti, rc=ierr)
          if (present(ierr)) then
             if (ierr == ESMF_SUCCESS) ierr = 0
          end if
+#endif
       end if
 
       !$omp barrier
@@ -382,9 +458,15 @@ module MPASAOS_timekeeping
 
       type (MPAS_TimeInterval_type) :: timeStep
 
+#ifdef DATMFORCEDRESTORING
+      call ESMFloc_ClockGet(clock % c, TimeStep=timeStep%ti, rc=ierr)
+      if (present(ierr)) then
+         if (ierr == ESMFloc_SUCCESS) ierr = 0
+#else
       call ESMF_ClockGet(clock % c, TimeStep=timeStep%ti, rc=ierr)
       if (present(ierr)) then
          if (ierr == ESMF_SUCCESS) ierr = 0
+#endif
       end if
 
       mpas_get_clock_timestep = timeStep
@@ -400,13 +482,28 @@ module MPASAOS_timekeeping
       type (MPAS_TimeInterval_type), intent(in), optional :: timeStep
       integer, intent(out), optional :: ierr
 
+#ifdef DATMFORCEDRESTORING
+      type (ESMFloc_TimeInterval) :: time_step
+#else
       type (ESMF_TimeInterval) :: time_step
+#endif
       integer :: threadNum
 
       threadNum = mpas_threading_get_thread_num()
 
       if ( threadNum == 0 ) then
          if (present(timeStep)) then
+#ifdef DATMFORCEDRESTORING
+            call ESMFloc_ClockGet(clock % c, TimeStep=time_step, rc=ierr)
+            call ESMFloc_ClockSet(clock % c, TimeStep=timeStep % ti, rc=ierr)
+            call ESMFloc_ClockAdvance(clock % c, rc=ierr)
+            call ESMFloc_ClockSet(clock % c, TimeStep=time_step, rc=ierr)
+         else
+            call ESMFloc_ClockAdvance(clock % c, rc=ierr)
+         end if
+         if (present(ierr)) then
+            if (ierr == ESMFloc_SUCCESS) ierr = 0
+#else
             call ESMF_ClockGet(clock % c, TimeStep=time_step, rc=ierr)
             call ESMF_ClockSet(clock % c, TimeStep=timeStep % ti, rc=ierr)
             call ESMF_ClockAdvance(clock % c, rc=ierr)
@@ -416,6 +513,7 @@ module MPASAOS_timekeeping
          end if
          if (present(ierr)) then
             if (ierr == ESMF_SUCCESS) ierr = 0
+#endif
          end if
       end if
 
@@ -438,6 +536,19 @@ module MPASAOS_timekeeping
 
       if ( threadNum == 0 ) then
          if (whichTime == MPAS_NOW) then
+#ifdef DATMFORCEDRESTORING
+            call ESMFloc_ClockSet(clock % c, CurrTime=clock_time%t, rc=ierr)
+            call mpas_calibrate_alarms(clock, ierr);
+         else if (whichTime == MPAS_START_TIME) then
+            call ESMFloc_ClockSet(clock % c, StartTime=clock_time%t, rc=ierr)
+         else if (whichTime == MPAS_STOP_TIME) then
+            call ESMFloc_ClockSet(clock % c, StopTime=clock_time%t, rc=ierr)
+         else if (present(ierr)) then
+            ierr = 1
+         end if
+         if (present(ierr)) then
+            if (ierr == ESMFloc_SUCCESS) ierr = 0
+#else
             call ESMF_ClockSet(clock % c, CurrTime=clock_time%t, rc=ierr)
             call mpas_calibrate_alarms(clock, ierr);
          else if (whichTime == MPAS_START_TIME) then
@@ -449,6 +560,7 @@ module MPASAOS_timekeeping
          end if
          if (present(ierr)) then
             if (ierr == ESMF_SUCCESS) ierr = 0
+#endif
          end if
       end if
 
@@ -468,6 +580,18 @@ module MPASAOS_timekeeping
       type (MPAS_Time_type) :: clock_time
 
       if (whichTime == MPAS_NOW) then
+#ifdef DATMFORCEDRESTORING
+         call ESMFloc_ClockGet(clock % c, CurrTime=clock_time%t, rc=ierr)
+      else if (whichTime == MPAS_START_TIME) then
+         call ESMFloc_ClockGet(clock % c, StartTime=clock_time%t, rc=ierr)
+      else if (whichTime == MPAS_STOP_TIME) then
+         call ESMFloc_ClockGet(clock % c, StopTime=clock_time%t, rc=ierr)
+      else if (present(ierr)) then
+         ierr = 1
+      end if
+      if (present(ierr)) then
+         if (ierr == ESMFloc_SUCCESS) ierr = 0
+#else
          call ESMF_ClockGet(clock % c, CurrTime=clock_time%t, rc=ierr)
       else if (whichTime == MPAS_START_TIME) then
          call ESMF_ClockGet(clock % c, StartTime=clock_time%t, rc=ierr)
@@ -478,6 +602,7 @@ module MPASAOS_timekeeping
       end if
       if (present(ierr)) then
          if (ierr == ESMF_SUCCESS) ierr = 0
+#endif
       end if
 
       mpas_get_clock_time = clock_time
@@ -555,8 +680,12 @@ module MPASAOS_timekeeping
             alarmPtr % prevRingTime = alarmTime
          end if
          if (present(ierr)) then
+#ifdef DATMFORCEDRESTORING
+            if (ierr == ESMFloc_SUCCESS) ierr = 0
+#else
             if (ierr == ESMF_SUCCESS) ierr = 0
-         end if
+#endif
+         endif
       end if
 
       !$omp barrier
@@ -1121,7 +1250,11 @@ module MPASAOS_timekeeping
          end do
    
          if (present(ierr)) then
+#ifdef DATMFORCEDRESTORING
+            if (ierr == ESMFloc_SUCCESS) ierr = 0
+#else
             if (ierr == ESMF_SUCCESS) ierr = 0
+#endif
          end if
       end if
 
@@ -1234,7 +1367,11 @@ module MPASAOS_timekeeping
             return
          end if
 
+#ifdef DATMFORCEDRESTORING
+         call ESMFloc_TimeSet(curr_time % t, YY=year, MM=month, DD=day, H=hour, M=min, S=sec, Sn=numerator, Sd=denominator, rc=ierr)
+#else
          call ESMF_TimeSet(curr_time % t, YY=year, MM=month, DD=day, H=hour, M=min, S=sec, Sn=numerator, Sd=denominator, rc=ierr)
+#endif
 
       else
       
@@ -1277,12 +1414,20 @@ module MPASAOS_timekeeping
             return
          end if
 
+#ifdef DATMFORCEDRESTORING
+         call ESMFloc_TimeSet(curr_time % t, YY=YYYY, MM=month, DD=day, H=H, M=M, S=S, Sn=S_n, Sd=S_d, rc=ierr)
+#else
          call ESMF_TimeSet(curr_time % t, YY=YYYY, MM=month, DD=day, H=H, M=M, S=S, Sn=S_n, Sd=S_d, rc=ierr)
+#endif
       
       end if
       
       if (present(ierr)) then
+#ifdef DATMFORCEDRESTORING
+         if (ierr == ESMFloc_SUCCESS) ierr = 0
+#else
          if (ierr == ESMF_SUCCESS) ierr = 0
+#endif
       end if
 
    end subroutine mpas_set_time
@@ -1307,12 +1452,18 @@ module MPASAOS_timekeeping
 
       integer :: idx
 
+#ifdef DATMFORCEDRESTORING
+      call ESMFloc_TimeGet(curr_time % t, YY=YYYY, MM=MM, DD=DD, H=H, M=M, S=S, Sn=S_n, Sd=S_d, rc=ierr)
+      call ESMFloc_TimeGet(curr_time % t, dayOfYear=DoY, rc=ierr)
+      call ESMFloc_TimeGet(curr_time % t, timeString=dateTimeString, rc=ierr)
+#else
       call ESMF_TimeGet(curr_time % t, YY=YYYY, MM=MM, DD=DD, H=H, M=M, S=S, Sn=S_n, Sd=S_d, rc=ierr)
       call ESMF_TimeGet(curr_time % t, dayOfYear=DoY, rc=ierr)
-#ifndef MPAS_EXTERNAL_ESMF_LIB
-      call ESMF_TimeGet(curr_time % t, timeString=dateTimeString, rc=ierr)
-#else
-      call ESMF_TimeGet(curr_time % t, timeStringISOFrac=dateTimeString, rc=ierr)
+    #ifndef MPAS_EXTERNAL_ESMF_LIB
+          call ESMF_TimeGet(curr_time % t, timeString=dateTimeString, rc=ierr)
+    #else
+          call ESMF_TimeGet(curr_time % t, timeStringISOFrac=dateTimeString, rc=ierr)
+    #endif
 #endif
 
       !
@@ -1328,7 +1479,11 @@ module MPASAOS_timekeeping
       end if
 
       if (present(ierr)) then
+#ifdef DATMFORCEDRESTORING
+         if (ierr == ESMFloc_SUCCESS) ierr = 0
+#else
          if (ierr == ESMF_SUCCESS) ierr = 0
+#endif
       end if
 
    end subroutine mpas_get_time
@@ -1558,11 +1713,19 @@ module MPASAOS_timekeeping
             return
          end if
 
+#ifdef DATMFORCEDRESTORING
+         call ESMFloc_TimeIntervalSet(interval % ti, YY=year, MM=month, D=day, H=hour, M=min, S_i8=sec, Sn=numerator, Sd=denominator, rc=ierr)
+#else
          call ESMF_TimeIntervalSet(interval % ti, YY=year, MM=month, D=day, H=hour, M=min, S_i8=sec, Sn=numerator, Sd=denominator, rc=ierr)
+#endif
 
       else
 
+#ifdef DATMFORCEDRESTORING
+         call ESMFloc_TimeIntervalSet(interval % ti, YY=YY, MM=MM, D=DD, H=H, M=M, S_i8=S_i8, S=S, Sn=S_n, Sd=S_d, rc=ierr)
+#else
          call ESMF_TimeIntervalSet(interval % ti, YY=YY, MM=MM, D=DD, H=H, M=M, S_i8=S_i8, S=S, Sn=S_n, Sd=S_d, rc=ierr)
+#endif
       
       end if
 
@@ -1610,19 +1773,46 @@ module MPASAOS_timekeeping
 
 
       if (present(StartTimeIn)) then
-         call ESMF_TimeIntervalGet(interval % ti, StartTimeIn=StartTimeIn%t, D=days, S_i8=seconds, Sn=sn, Sd=sd, rc=ierr)
+#ifdef DATMFORCEDRESTORING
+         call ESMFloc_TimeIntervalGet(interval % ti, StartTimeIn=StartTimeIn%t, D=days, S_i8=seconds, Sn=sn, Sd=sd, rc=ierr)
       else
-#ifndef MPAS_EXTERNAL_ESMF_LIB
+    !#ifndef MPAS_EXTERNAL_ESMF_LIB
           if ( interval % ti % YR /= 0 .or. interval % ti % MM /= 0 ) then
              if (present(ierr)) ierr = 1
              call mpas_log_write('mpas_get_timeInterval cannnot return time interval information for an interval containing ' // &
                  'months and years without a startTimeIn argument.', MPAS_LOG_ERR)
              return
           end if
-#endif
+    !#endif
+          call ESMFloc_TimeIntervalGet(interval % ti, D=days, S_i8=seconds, Sn=sn, Sd=sd, rc=local_ierr)
+          if (present(ierr)) ierr = local_ierr
+    !#ifdef MPAS_EXTERNAL_ESMF_LIB
+    !          !
+    !          ! With an external ESMF library, treat the time interval type as opaque, and just
+    !          ! assume that a non-success error code will be returned if the interval cannot be retrieved.
+    !          !
+    !          if (local_ierr /= ESMF_SUCCESS) then
+    !             call mpas_log_write('mpas_get_timeInterval cannnot return time interval information for an interval containing ' // &
+    !                 'months and years without a startTimeIn argument.', MPAS_LOG_ERR)
+    !             return
+    !          end if
+    !#endif
+      endif
+
+#else
+         call ESMF_TimeIntervalGet(interval % ti, StartTimeIn=StartTimeIn%t, D=days, S_i8=seconds, Sn=sn, Sd=sd, rc=ierr)
+      else
+    #ifndef MPAS_EXTERNAL_ESMF_LIB
+          if ( interval % ti % YR /= 0 .or. interval % ti % MM /= 0 ) then
+             if (present(ierr)) ierr = 1
+             call mpas_log_write('mpas_get_timeInterval cannnot return time interval information for an interval containing ' // &
+                 'months and years without a startTimeIn argument.', MPAS_LOG_ERR)
+             return
+          end if
+    #endif
           call ESMF_TimeIntervalGet(interval % ti, D=days, S_i8=seconds, Sn=sn, Sd=sd, rc=local_ierr)
           if (present(ierr)) ierr = local_ierr
-#ifdef MPAS_EXTERNAL_ESMF_LIB
+    #ifdef MPAS_EXTERNAL_ESMF_LIB
           !
           ! With an external ESMF library, treat the time interval type as opaque, and just
           ! assume that a non-success error code will be returned if the interval cannot be retrieved.
@@ -1632,8 +1822,9 @@ module MPASAOS_timekeeping
                  'months and years without a startTimeIn argument.', MPAS_LOG_ERR)
              return
           end if
-#endif
+    #endif
       endif
+#endif
 
       if (sd == 0) then   ! may only occur if (sn == 0)?
          sd = 1
@@ -1680,9 +1871,45 @@ module MPASAOS_timekeeping
       end if
 
       if (present(timeString)) then
-#ifndef MPAS_EXTERNAL_ESMF_LIB
-         call ESMF_TimeIntervalGet(interval % ti, timeString=timeString, rc=ierr)
+#ifdef DATMFORCEDRESTORING
+
+    !#ifndef MPAS_EXTERNAL_ESMF_LIB
+         call ESMFloc_TimeIntervalGet(interval % ti, timeString=timeString, rc=ierr)
+    !#else
+    !         !
+    !         ! In case an external ESMF library is being used, the time interval may be returned in
+    !         ! ISO period format, in which case it is easier to build a time interval string in MPAS
+    !         ! format given days, hours, minutes, and seconds.
+    !         !
+    !         call ESMF_TimeIntervalGet(interval % ti, StartTimeIn=StartTimeIn%t, &
+    !                                   d=days, h=hours, m=minutes, s_i8=seconds, sN=sn, sD=sd, rc=ierr)
+    !         seconds_real = real(seconds,kind=R8KIND) + (real(sn, kind=R8KIND) / real(sd, kind=R8KIND))
+    !
+    !         !
+    !         ! If the time interval is negative, the ESMF library will return negative values for
+    !         ! non-zero components of the interval, so days, hours, minutes, and seconds_real must
+    !         ! be checked in order to determine whether a '-' needs to be prepended to the timeString
+    !         !
+    !         neg = ''
+    !         if (days < 0 .or. hours < 0 .or. minutes < 0 .or. seconds_real < 0.0_R8KIND) then
+    !            neg = '-'
+    !         end if
+    !
+    !         write(timeString,'(a,i9.9,a,i2.2,a,i2.2,a,i2.2,f10.9)') trim(neg), abs(days), '_', abs(hours), ':', abs(minutes), ':', &
+    !                                                               int(abs(seconds_real)), abs(seconds_real) - int(abs(seconds_real))
+    !#endif
+
+      end if
+
+      if (present(ierr)) then
+         if (ierr == ESMFloc_SUCCESS) ierr = 0
+      end if
+
 #else
+
+    #ifndef MPAS_EXTERNAL_ESMF_LIB
+         call ESMF_TimeIntervalGet(interval % ti, timeString=timeString, rc=ierr)
+    #else
          !
          ! In case an external ESMF library is being used, the time interval may be returned in
          ! ISO period format, in which case it is easier to build a time interval string in MPAS
@@ -1704,12 +1931,15 @@ module MPASAOS_timekeeping
 
          write(timeString,'(a,i9.9,a,i2.2,a,i2.2,a,i2.2,f10.9)') trim(neg), abs(days), '_', abs(hours), ':', abs(minutes), ':', &
                                                                int(abs(seconds_real)), abs(seconds_real) - int(abs(seconds_real))
-#endif
+    #endif
+
       end if
 
       if (present(ierr)) then
          if (ierr == ESMF_SUCCESS) ierr = 0
       end if
+
+#endif
 
    end subroutine mpas_get_timeInterval
 
@@ -1790,20 +2020,28 @@ module MPASAOS_timekeeping
       type (MPAS_TimeInterval_type), intent(in) :: ti
       integer (kind=I8KIND), intent(in) :: n8
 
-#ifndef MPAS_EXTERNAL_ESMF_LIB
-      mul_ti_n8 % ti = ti % ti * n8
+#ifdef DATMFORCEDRESTORING
+
+        mul_ti_n8 % ti = ti % ti * n8
+
 #else
-      !
-      ! At present, the external ESMF library does not support multiplying a time interval
-      ! by an 8-byte integer, so we convert to a 4-byte integer whenever possible.
-      ! However, if the value of the 8-byte integer exceeds what can be represented by
-      ! a 4-byte integer, stop with a critical error.
-      !
-      if (n8 > huge(int(n8)) .or. n8 < -huge(int(n8))) then
-         call mpas_log_write('(time interval) * 64-bit integer: integer out of range for external ESMF library', &
-                             messageType=MPAS_LOG_CRIT)
-      end if
-      mul_ti_n8 % ti = ti % ti * int(n8)
+
+    #ifndef MPAS_EXTERNAL_ESMF_LIB
+        mul_ti_n8 % ti = ti % ti * n8
+    #else
+        !
+        ! At present, the external ESMF library does not support multiplying a time interval
+        ! by an 8-byte integer, so we convert to a 4-byte integer whenever possible.
+        ! However, if the value of the 8-byte integer exceeds what can be represented by
+        ! a 4-byte integer, stop with a critical error.
+        !
+        if (n8 > huge(int(n8)) .or. n8 < -huge(int(n8))) then
+           call mpas_log_write('(time interval) * 64-bit integer: integer out of range for external ESMF library', &
+                               messageType=MPAS_LOG_CRIT)
+        end if
+        mul_ti_n8 % ti = ti % ti * int(n8)
+    #endif
+
 #endif
 
    end function mul_ti_n8
@@ -2063,11 +2301,19 @@ module MPASAOS_timekeeping
       integer :: rc
       integer :: D, S, Sn, Sd
 
+#ifdef DATMFORCEDRESTORING
+      call ESMFloc_TimeIntervalGet(ti % ti, D=D, S=S, Sn=Sn, Sd=Sd, rc=rc)
+      D    = -D 
+      S    = -S 
+      Sn   = -Sn
+      call ESMFloc_TimeIntervalSet(neg_ti % ti, D=D, S=S, Sn=Sn, Sd=Sd, rc=rc)
+#else
       call ESMF_TimeIntervalGet(ti % ti, D=D, S=S, Sn=Sn, Sd=Sd, rc=rc)
       D    = -D 
       S    = -S 
       Sn   = -Sn
       call ESMF_TimeIntervalSet(neg_ti % ti, D=D, S=S, Sn=Sn, Sd=Sd, rc=rc)
+#endif
 
    end function neg_ti
 
@@ -2082,6 +2328,19 @@ module MPASAOS_timekeeping
       integer :: rc
       integer :: D, S, Sn, Sd
 
+#ifdef DATMFORCEDRESTORING
+      call ESMFloc_TimeIntervalSet(zeroInterval % ti, D=0, H=0, M=0, S=0, rc=rc)
+
+      if(ti < zeroInterval) then
+         call ESMFloc_TimeIntervalGet(ti % ti, D=D, S=S, Sn=Sn, Sd=Sd, rc=rc)
+         D    = -D 
+         S    = -S 
+         Sn   = -Sn
+         call ESMFloc_TimeIntervalSet(abs_ti % ti, D=D, S=S, Sn=Sn, Sd=Sd, rc=rc)
+      else
+         abs_ti = ti
+      end if
+#else
       call ESMF_TimeIntervalSet(zeroInterval % ti, D=0, H=0, M=0, S=0, rc=rc)
 
       if(ti < zeroInterval) then
@@ -2093,6 +2352,7 @@ module MPASAOS_timekeeping
       else
          abs_ti = ti
       end if
+#endif
 
    end function abs_ti
 

--- a/src/framework-sed/mpas_timekeeping.F
+++ b/src/framework-sed/mpas_timekeeping.F
@@ -105,32 +105,32 @@ module MPASAOS_timekeeping
 
 #else
 
-    #ifndef MPAS_NO_ESMF_INIT
-        #ifndef MPAS_EXTERNAL_ESMF_LIB
+#ifndef MPAS_NO_ESMF_INIT
+#ifndef MPAS_EXTERNAL_ESMF_LIB
             call ESMF_Initialize(defaultCalendar=ESMF_CALKIND_GREGORIAN)
-        #else
+#else
             call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_GREGORIAN)
-        #endif
-    #endif
+#endif
+#endif
     else if (trim(calendar) == 'noleap') then
          TheCalendar = MPAS_GREGORIAN_NOLEAP
-    #ifndef MPAS_NO_ESMF_INIT
-        #ifndef MPAS_EXTERNAL_ESMF_LIB
+#ifndef MPAS_NO_ESMF_INIT
+#ifndef MPAS_EXTERNAL_ESMF_LIB
              call ESMF_Initialize(defaultCalendar=ESMF_CALKIND_NOLEAP)
-        #else
+#else
              call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_NOLEAP)
-        #endif
-    #endif
+#endif
+#endif
       else if (trim(calendar) == '360day') then
         TheCalendar = MPAS_360DAY
-    #ifndef MPAS_NO_ESMF_INIT
-        #ifndef MPAS_EXTERNAL_ESMF_LIB
+#ifndef MPAS_NO_ESMF_INIT
+#ifndef MPAS_EXTERNAL_ESMF_LIB
         !    call ESMF_Initialize(defaultCalendar=ESMF_CALKIND_360DAY)
              call mpas_log_write('mpas_timekeeping_init: 360-day calendar not supported with the built-in ESMF timekeeping library', MPAS_LOG_ERR)
-        #else
+#else
              call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_360DAY)
-        #endif
-    #endif
+#endif
+#endif
 
 #endif
 
@@ -148,9 +148,9 @@ module MPASAOS_timekeeping
       implicit none
 
 #ifndef DATMFORCEDRESTORING
-    #ifndef MPAS_NO_ESMF_INIT
+#ifndef MPAS_NO_ESMF_INIT
         call ESMF_Finalize()
-    #endif
+#endif
 #endif
 
    end subroutine mpas_timekeeping_finalize
@@ -187,9 +187,9 @@ module MPASAOS_timekeeping
 #ifdef DATMFORCEDRESTORING
         call ESMFloc_setYearWidth(yearWidthIn)
 #else
-    #ifndef MPAS_EXTERNAL_ESMF_LIB
+#ifndef MPAS_EXTERNAL_ESMF_LIB
         call ESMF_setYearWidth(yearWidthIn)
-    #endif
+#endif
 #endif
 
    end subroutine mpas_timekeeping_set_year_width!}}}
@@ -1459,11 +1459,11 @@ module MPASAOS_timekeeping
 #else
       call ESMF_TimeGet(curr_time % t, YY=YYYY, MM=MM, DD=DD, H=H, M=M, S=S, Sn=S_n, Sd=S_d, rc=ierr)
       call ESMF_TimeGet(curr_time % t, dayOfYear=DoY, rc=ierr)
-    #ifndef MPAS_EXTERNAL_ESMF_LIB
+#ifndef MPAS_EXTERNAL_ESMF_LIB
           call ESMF_TimeGet(curr_time % t, timeString=dateTimeString, rc=ierr)
-    #else
+#else
           call ESMF_TimeGet(curr_time % t, timeStringISOFrac=dateTimeString, rc=ierr)
-    #endif
+#endif
 #endif
 
       !
@@ -1802,17 +1802,17 @@ module MPASAOS_timekeeping
 #else
          call ESMF_TimeIntervalGet(interval % ti, StartTimeIn=StartTimeIn%t, D=days, S_i8=seconds, Sn=sn, Sd=sd, rc=ierr)
       else
-    #ifndef MPAS_EXTERNAL_ESMF_LIB
+#ifndef MPAS_EXTERNAL_ESMF_LIB
           if ( interval % ti % YR /= 0 .or. interval % ti % MM /= 0 ) then
              if (present(ierr)) ierr = 1
              call mpas_log_write('mpas_get_timeInterval cannnot return time interval information for an interval containing ' // &
                  'months and years without a startTimeIn argument.', MPAS_LOG_ERR)
              return
           end if
-    #endif
+#endif
           call ESMF_TimeIntervalGet(interval % ti, D=days, S_i8=seconds, Sn=sn, Sd=sd, rc=local_ierr)
           if (present(ierr)) ierr = local_ierr
-    #ifdef MPAS_EXTERNAL_ESMF_LIB
+#ifdef MPAS_EXTERNAL_ESMF_LIB
           !
           ! With an external ESMF library, treat the time interval type as opaque, and just
           ! assume that a non-success error code will be returned if the interval cannot be retrieved.
@@ -1822,7 +1822,7 @@ module MPASAOS_timekeeping
                  'months and years without a startTimeIn argument.', MPAS_LOG_ERR)
              return
           end if
-    #endif
+#endif
       endif
 #endif
 
@@ -1907,9 +1907,9 @@ module MPASAOS_timekeeping
 
 #else
 
-    #ifndef MPAS_EXTERNAL_ESMF_LIB
+#ifndef MPAS_EXTERNAL_ESMF_LIB
          call ESMF_TimeIntervalGet(interval % ti, timeString=timeString, rc=ierr)
-    #else
+#else
          !
          ! In case an external ESMF library is being used, the time interval may be returned in
          ! ISO period format, in which case it is easier to build a time interval string in MPAS
@@ -1931,7 +1931,7 @@ module MPASAOS_timekeeping
 
          write(timeString,'(a,i9.9,a,i2.2,a,i2.2,a,i2.2,f10.9)') trim(neg), abs(days), '_', abs(hours), ':', abs(minutes), ':', &
                                                                int(abs(seconds_real)), abs(seconds_real) - int(abs(seconds_real))
-    #endif
+#endif
 
       end if
 
@@ -2026,9 +2026,9 @@ module MPASAOS_timekeeping
 
 #else
 
-    #ifndef MPAS_EXTERNAL_ESMF_LIB
+#ifndef MPAS_EXTERNAL_ESMF_LIB
         mul_ti_n8 % ti = ti % ti * n8
-    #else
+#else
         !
         ! At present, the external ESMF library does not support multiplying a time interval
         ! by an 8-byte integer, so we convert to a 4-byte integer whenever possible.
@@ -2040,7 +2040,7 @@ module MPASAOS_timekeeping
                                messageType=MPAS_LOG_CRIT)
         end if
         mul_ti_n8 % ti = ti % ti * int(n8)
-    #endif
+#endif
 
 #endif
 

--- a/src/framework-sed/mpas_timekeeping.F
+++ b/src/framework-sed/mpas_timekeeping.F
@@ -13,11 +13,7 @@ module MPASAOS_timekeeping
    use MPASAOS_threading
    use MPASAOS_log
 
-#ifdef DATMFORCEDRESTORING
    use ESMFloc
-#else
-   use ESMF
-#endif
 
    private :: mpas_calibrate_alarms
    private :: mpas_in_ringing_envelope
@@ -96,43 +92,11 @@ module MPASAOS_timekeeping
       if (trim(calendar) == 'gregorian') then
          TheCalendar = MPAS_GREGORIAN
 
-#ifdef DATMFORCEDRESTORING
 
          call ESMFloc_Initialize(defaultCalendar=ESMFloc_CALKIND_GREGORIAN)
       else if (trim(calendar) == 'noleap') then
          TheCalendar = MPAS_GREGORIAN_NOLEAP
          call ESMFloc_Initialize(defaultCalendar=ESMFloc_CALKIND_NOLEAP)
-
-#else
-
-#ifndef MPAS_NO_ESMF_INIT
-#ifndef MPAS_EXTERNAL_ESMF_LIB
-            call ESMF_Initialize(defaultCalendar=ESMF_CALKIND_GREGORIAN)
-#else
-            call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_GREGORIAN)
-#endif
-#endif
-    else if (trim(calendar) == 'noleap') then
-         TheCalendar = MPAS_GREGORIAN_NOLEAP
-#ifndef MPAS_NO_ESMF_INIT
-#ifndef MPAS_EXTERNAL_ESMF_LIB
-             call ESMF_Initialize(defaultCalendar=ESMF_CALKIND_NOLEAP)
-#else
-             call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_NOLEAP)
-#endif
-#endif
-      else if (trim(calendar) == '360day') then
-        TheCalendar = MPAS_360DAY
-#ifndef MPAS_NO_ESMF_INIT
-#ifndef MPAS_EXTERNAL_ESMF_LIB
-        !    call ESMF_Initialize(defaultCalendar=ESMF_CALKIND_360DAY)
-             call mpas_log_write('mpas_timekeeping_init: 360-day calendar not supported with the built-in ESMF timekeeping library', MPAS_LOG_ERR)
-#else
-             call ESMF_Initialize(defaultCalKind=ESMF_CALKIND_360DAY)
-#endif
-#endif
-
-#endif
 
       else
          call mpas_log_write('mpas_timekeeping_init: Invalid calendar type', MPAS_LOG_ERR)
@@ -146,12 +110,6 @@ module MPASAOS_timekeeping
    subroutine mpas_timekeeping_finalize()
 
       implicit none
-
-#ifndef DATMFORCEDRESTORING
-#ifndef MPAS_NO_ESMF_INIT
-        call ESMF_Finalize()
-#endif
-#endif
 
    end subroutine mpas_timekeeping_finalize
 
@@ -184,13 +142,7 @@ module MPASAOS_timekeeping
      ! though this may not be a problem, since the library appears to return time strings
      ! with as many digits as are needed to represent the year.
      !
-#ifdef DATMFORCEDRESTORING
         call ESMFloc_setYearWidth(yearWidthIn)
-#else
-#ifndef MPAS_EXTERNAL_ESMF_LIB
-        call ESMF_setYearWidth(yearWidthIn)
-#endif
-#endif
 
    end subroutine mpas_timekeeping_set_year_width!}}}
 
@@ -228,17 +180,10 @@ module MPASAOS_timekeeping
             return
          end if
 
-#ifdef DATMFORCEDRESTORING
          clock % c = ESMFloc_ClockCreate(TimeStep=timeStep%ti, StartTime=startTime%t, StopTime=stop_time%t, rc=ierr)
          if (present(ierr)) then
             if (ierr == ESMFloc_SUCCESS) ierr = 0
          end if
-#else
-         clock % c = ESMF_ClockCreate(TimeStep=timeStep%ti, StartTime=startTime%t, StopTime=stop_time%t, rc=ierr)
-         if (present(ierr)) then
-            if (ierr == ESMF_SUCCESS) ierr = 0
-         end if
-#endif
          clock % direction = MPAS_FORWARD
          clock % nAlarms = 0
          nullify(clock % alarmListHead)
@@ -269,17 +214,10 @@ module MPASAOS_timekeeping
             alarmPtr => clock % alarmListHead
          end do
 
-#ifdef DATMFORCEDRESTORING
          call ESMFloc_ClockDestroy(clock % c, rc=ierr)
          if (present(ierr)) then
             if (ierr == ESMFloc_SUCCESS) ierr = 0
          end if
-#else
-         call ESMF_ClockDestroy(clock % c, rc=ierr)
-         if (present(ierr)) then
-            if (ierr == ESMF_SUCCESS) ierr = 0
-         end if
-#endif
       end if
 
       !$omp barrier
@@ -294,7 +232,6 @@ module MPASAOS_timekeeping
       type (MPAS_Clock_type), intent(in) :: clock
       integer, intent(out), optional :: ierr
 
-#ifdef DATMFORCEDRESTORING
       type (ESMFloc_Time) :: currTime, startTime, stopTime
 
       call ESMFloc_ClockGet(clock % c, CurrTime=currTime, rc=ierr)
@@ -303,16 +240,6 @@ module MPASAOS_timekeeping
       if (present(ierr)) then
          if (ierr == ESMFloc_SUCCESS) ierr = 0
       end if
-#else
-      type (ESMF_Time) :: currTime, startTime, stopTime
-
-      call ESMF_ClockGet(clock % c, CurrTime=currTime, rc=ierr)
-      call ESMF_ClockGet(clock % c, StartTime=startTime, rc=ierr)
-      call ESMF_ClockGet(clock % c, StopTime=stopTime, rc=ierr)
-      if (present(ierr)) then
-         if (ierr == ESMF_SUCCESS) ierr = 0
-      end if
-#endif
 
       if (startTime <= stopTime) then
          mpas_is_clock_start_time = (currTime <= startTime)
@@ -330,7 +257,6 @@ module MPASAOS_timekeeping
       type (MPAS_Clock_type), intent(in) :: clock
       integer, intent(out), optional :: ierr
 
-#ifdef DATMFORCEDRESTORING
       type (ESMFloc_Time) :: currTime, startTime, stopTime
 
       call ESMFloc_ClockGet(clock % c, CurrTime=currTime, rc=ierr)
@@ -339,16 +265,6 @@ module MPASAOS_timekeeping
       if (present(ierr)) then
          if (ierr == ESMFloc_SUCCESS) ierr = 0
       end if
-#else
-      type (ESMF_Time) :: currTime, startTime, stopTime
-
-      call ESMF_ClockGet(clock % c, CurrTime=currTime, rc=ierr)
-      call ESMF_ClockGet(clock % c, StartTime=startTime, rc=ierr)
-      call ESMF_ClockGet(clock % c, StopTime=stopTime, rc=ierr)
-      if (present(ierr)) then
-         if (ierr == ESMF_SUCCESS) ierr = 0
-      end if
-#endif
 
       if (startTime <= stopTime) then
          mpas_is_clock_stop_time = (currTime >= stopTime)
@@ -377,25 +293,15 @@ module MPASAOS_timekeeping
 
       if ( threadNum == 0 ) then
          clock % direction = direction
-#ifdef DATMFORCEDRESTORING
          call ESMFloc_ClockGet(clock % c, TimeStep=timeStep%ti, rc=ierr)
          timeStep = neg_ti(timeStep)
          call ESMFloc_ClockSet(clock % c, TimeStep=timeStep%ti, rc=ierr)
-#else
-         call ESMF_ClockGet(clock % c, TimeStep=timeStep%ti, rc=ierr)
-         timeStep = neg_ti(timeStep)
-         call ESMF_ClockSet(clock % c, TimeStep=timeStep%ti, rc=ierr)
-#endif
 
          ! specify a valid previousRingTime for each alarm
          call mpas_calibrate_alarms(clock, ierr);
 
          if (present(ierr)) then
-#ifdef DATMFORCEDRESTORING
             if (ierr == ESMFloc_SUCCESS) ierr = 0
-#else
-            if (ierr == ESMF_SUCCESS) ierr = 0
-#endif
          end if
       end if
 
@@ -431,17 +337,10 @@ module MPASAOS_timekeeping
       threadNum = mpas_threading_get_thread_num()
 
       if ( threadNum == 0 ) then
-#ifdef DATMFORCEDRESTORING
          call ESMFloc_ClockSet(clock % c, TimeStep=timeStep%ti, rc=ierr)
          if (present(ierr)) then
             if (ierr == ESMFloc_SUCCESS) ierr = 0
          end if
-#else
-         call ESMF_ClockSet(clock % c, TimeStep=timeStep%ti, rc=ierr)
-         if (present(ierr)) then
-            if (ierr == ESMF_SUCCESS) ierr = 0
-         end if
-#endif
       end if
 
       !$omp barrier
@@ -458,15 +357,9 @@ module MPASAOS_timekeeping
 
       type (MPAS_TimeInterval_type) :: timeStep
 
-#ifdef DATMFORCEDRESTORING
       call ESMFloc_ClockGet(clock % c, TimeStep=timeStep%ti, rc=ierr)
       if (present(ierr)) then
          if (ierr == ESMFloc_SUCCESS) ierr = 0
-#else
-      call ESMF_ClockGet(clock % c, TimeStep=timeStep%ti, rc=ierr)
-      if (present(ierr)) then
-         if (ierr == ESMF_SUCCESS) ierr = 0
-#endif
       end if
 
       mpas_get_clock_timestep = timeStep
@@ -482,18 +375,13 @@ module MPASAOS_timekeeping
       type (MPAS_TimeInterval_type), intent(in), optional :: timeStep
       integer, intent(out), optional :: ierr
 
-#ifdef DATMFORCEDRESTORING
       type (ESMFloc_TimeInterval) :: time_step
-#else
-      type (ESMF_TimeInterval) :: time_step
-#endif
       integer :: threadNum
 
       threadNum = mpas_threading_get_thread_num()
 
       if ( threadNum == 0 ) then
          if (present(timeStep)) then
-#ifdef DATMFORCEDRESTORING
             call ESMFloc_ClockGet(clock % c, TimeStep=time_step, rc=ierr)
             call ESMFloc_ClockSet(clock % c, TimeStep=timeStep % ti, rc=ierr)
             call ESMFloc_ClockAdvance(clock % c, rc=ierr)
@@ -503,17 +391,6 @@ module MPASAOS_timekeeping
          end if
          if (present(ierr)) then
             if (ierr == ESMFloc_SUCCESS) ierr = 0
-#else
-            call ESMF_ClockGet(clock % c, TimeStep=time_step, rc=ierr)
-            call ESMF_ClockSet(clock % c, TimeStep=timeStep % ti, rc=ierr)
-            call ESMF_ClockAdvance(clock % c, rc=ierr)
-            call ESMF_ClockSet(clock % c, TimeStep=time_step, rc=ierr)
-         else
-            call ESMF_ClockAdvance(clock % c, rc=ierr)
-         end if
-         if (present(ierr)) then
-            if (ierr == ESMF_SUCCESS) ierr = 0
-#endif
          end if
       end if
 
@@ -536,7 +413,6 @@ module MPASAOS_timekeeping
 
       if ( threadNum == 0 ) then
          if (whichTime == MPAS_NOW) then
-#ifdef DATMFORCEDRESTORING
             call ESMFloc_ClockSet(clock % c, CurrTime=clock_time%t, rc=ierr)
             call mpas_calibrate_alarms(clock, ierr);
          else if (whichTime == MPAS_START_TIME) then
@@ -548,19 +424,6 @@ module MPASAOS_timekeeping
          end if
          if (present(ierr)) then
             if (ierr == ESMFloc_SUCCESS) ierr = 0
-#else
-            call ESMF_ClockSet(clock % c, CurrTime=clock_time%t, rc=ierr)
-            call mpas_calibrate_alarms(clock, ierr);
-         else if (whichTime == MPAS_START_TIME) then
-            call ESMF_ClockSet(clock % c, StartTime=clock_time%t, rc=ierr)
-         else if (whichTime == MPAS_STOP_TIME) then
-            call ESMF_ClockSet(clock % c, StopTime=clock_time%t, rc=ierr)
-         else if (present(ierr)) then
-            ierr = 1
-         end if
-         if (present(ierr)) then
-            if (ierr == ESMF_SUCCESS) ierr = 0
-#endif
          end if
       end if
 
@@ -580,7 +443,6 @@ module MPASAOS_timekeeping
       type (MPAS_Time_type) :: clock_time
 
       if (whichTime == MPAS_NOW) then
-#ifdef DATMFORCEDRESTORING
          call ESMFloc_ClockGet(clock % c, CurrTime=clock_time%t, rc=ierr)
       else if (whichTime == MPAS_START_TIME) then
          call ESMFloc_ClockGet(clock % c, StartTime=clock_time%t, rc=ierr)
@@ -591,18 +453,6 @@ module MPASAOS_timekeeping
       end if
       if (present(ierr)) then
          if (ierr == ESMFloc_SUCCESS) ierr = 0
-#else
-         call ESMF_ClockGet(clock % c, CurrTime=clock_time%t, rc=ierr)
-      else if (whichTime == MPAS_START_TIME) then
-         call ESMF_ClockGet(clock % c, StartTime=clock_time%t, rc=ierr)
-      else if (whichTime == MPAS_STOP_TIME) then
-         call ESMF_ClockGet(clock % c, StopTime=clock_time%t, rc=ierr)
-      else if (present(ierr)) then
-         ierr = 1
-      end if
-      if (present(ierr)) then
-         if (ierr == ESMF_SUCCESS) ierr = 0
-#endif
       end if
 
       mpas_get_clock_time = clock_time
@@ -680,11 +530,7 @@ module MPASAOS_timekeeping
             alarmPtr % prevRingTime = alarmTime
          end if
          if (present(ierr)) then
-#ifdef DATMFORCEDRESTORING
             if (ierr == ESMFloc_SUCCESS) ierr = 0
-#else
-            if (ierr == ESMF_SUCCESS) ierr = 0
-#endif
          endif
       end if
 
@@ -1250,11 +1096,7 @@ module MPASAOS_timekeeping
          end do
    
          if (present(ierr)) then
-#ifdef DATMFORCEDRESTORING
             if (ierr == ESMFloc_SUCCESS) ierr = 0
-#else
-            if (ierr == ESMF_SUCCESS) ierr = 0
-#endif
          end if
       end if
 
@@ -1367,11 +1209,7 @@ module MPASAOS_timekeeping
             return
          end if
 
-#ifdef DATMFORCEDRESTORING
          call ESMFloc_TimeSet(curr_time % t, YY=year, MM=month, DD=day, H=hour, M=min, S=sec, Sn=numerator, Sd=denominator, rc=ierr)
-#else
-         call ESMF_TimeSet(curr_time % t, YY=year, MM=month, DD=day, H=hour, M=min, S=sec, Sn=numerator, Sd=denominator, rc=ierr)
-#endif
 
       else
       
@@ -1414,20 +1252,12 @@ module MPASAOS_timekeeping
             return
          end if
 
-#ifdef DATMFORCEDRESTORING
          call ESMFloc_TimeSet(curr_time % t, YY=YYYY, MM=month, DD=day, H=H, M=M, S=S, Sn=S_n, Sd=S_d, rc=ierr)
-#else
-         call ESMF_TimeSet(curr_time % t, YY=YYYY, MM=month, DD=day, H=H, M=M, S=S, Sn=S_n, Sd=S_d, rc=ierr)
-#endif
       
       end if
       
       if (present(ierr)) then
-#ifdef DATMFORCEDRESTORING
          if (ierr == ESMFloc_SUCCESS) ierr = 0
-#else
-         if (ierr == ESMF_SUCCESS) ierr = 0
-#endif
       end if
 
    end subroutine mpas_set_time
@@ -1452,19 +1282,9 @@ module MPASAOS_timekeeping
 
       integer :: idx
 
-#ifdef DATMFORCEDRESTORING
       call ESMFloc_TimeGet(curr_time % t, YY=YYYY, MM=MM, DD=DD, H=H, M=M, S=S, Sn=S_n, Sd=S_d, rc=ierr)
       call ESMFloc_TimeGet(curr_time % t, dayOfYear=DoY, rc=ierr)
       call ESMFloc_TimeGet(curr_time % t, timeString=dateTimeString, rc=ierr)
-#else
-      call ESMF_TimeGet(curr_time % t, YY=YYYY, MM=MM, DD=DD, H=H, M=M, S=S, Sn=S_n, Sd=S_d, rc=ierr)
-      call ESMF_TimeGet(curr_time % t, dayOfYear=DoY, rc=ierr)
-#ifndef MPAS_EXTERNAL_ESMF_LIB
-          call ESMF_TimeGet(curr_time % t, timeString=dateTimeString, rc=ierr)
-#else
-          call ESMF_TimeGet(curr_time % t, timeStringISOFrac=dateTimeString, rc=ierr)
-#endif
-#endif
 
       !
       ! In case an external ESMF library that returns ISO timestamps is being used,
@@ -1479,11 +1299,7 @@ module MPASAOS_timekeeping
       end if
 
       if (present(ierr)) then
-#ifdef DATMFORCEDRESTORING
          if (ierr == ESMFloc_SUCCESS) ierr = 0
-#else
-         if (ierr == ESMF_SUCCESS) ierr = 0
-#endif
       end if
 
    end subroutine mpas_get_time
@@ -1713,19 +1529,11 @@ module MPASAOS_timekeeping
             return
          end if
 
-#ifdef DATMFORCEDRESTORING
          call ESMFloc_TimeIntervalSet(interval % ti, YY=year, MM=month, D=day, H=hour, M=min, S_i8=sec, Sn=numerator, Sd=denominator, rc=ierr)
-#else
-         call ESMF_TimeIntervalSet(interval % ti, YY=year, MM=month, D=day, H=hour, M=min, S_i8=sec, Sn=numerator, Sd=denominator, rc=ierr)
-#endif
 
       else
 
-#ifdef DATMFORCEDRESTORING
          call ESMFloc_TimeIntervalSet(interval % ti, YY=YY, MM=MM, D=DD, H=H, M=M, S_i8=S_i8, S=S, Sn=S_n, Sd=S_d, rc=ierr)
-#else
-         call ESMF_TimeIntervalSet(interval % ti, YY=YY, MM=MM, D=DD, H=H, M=M, S_i8=S_i8, S=S, Sn=S_n, Sd=S_d, rc=ierr)
-#endif
       
       end if
 
@@ -1773,7 +1581,6 @@ module MPASAOS_timekeeping
 
 
       if (present(StartTimeIn)) then
-#ifdef DATMFORCEDRESTORING
          call ESMFloc_TimeIntervalGet(interval % ti, StartTimeIn=StartTimeIn%t, D=days, S_i8=seconds, Sn=sn, Sd=sd, rc=ierr)
       else
     !#ifndef MPAS_EXTERNAL_ESMF_LIB
@@ -1798,33 +1605,6 @@ module MPASAOS_timekeeping
     !          end if
     !#endif
       endif
-
-#else
-         call ESMF_TimeIntervalGet(interval % ti, StartTimeIn=StartTimeIn%t, D=days, S_i8=seconds, Sn=sn, Sd=sd, rc=ierr)
-      else
-#ifndef MPAS_EXTERNAL_ESMF_LIB
-          if ( interval % ti % YR /= 0 .or. interval % ti % MM /= 0 ) then
-             if (present(ierr)) ierr = 1
-             call mpas_log_write('mpas_get_timeInterval cannnot return time interval information for an interval containing ' // &
-                 'months and years without a startTimeIn argument.', MPAS_LOG_ERR)
-             return
-          end if
-#endif
-          call ESMF_TimeIntervalGet(interval % ti, D=days, S_i8=seconds, Sn=sn, Sd=sd, rc=local_ierr)
-          if (present(ierr)) ierr = local_ierr
-#ifdef MPAS_EXTERNAL_ESMF_LIB
-          !
-          ! With an external ESMF library, treat the time interval type as opaque, and just
-          ! assume that a non-success error code will be returned if the interval cannot be retrieved.
-          !
-          if (local_ierr /= ESMF_SUCCESS) then
-             call mpas_log_write('mpas_get_timeInterval cannnot return time interval information for an interval containing ' // &
-                 'months and years without a startTimeIn argument.', MPAS_LOG_ERR)
-             return
-          end if
-#endif
-      endif
-#endif
 
       if (sd == 0) then   ! may only occur if (sn == 0)?
          sd = 1
@@ -1871,7 +1651,6 @@ module MPASAOS_timekeeping
       end if
 
       if (present(timeString)) then
-#ifdef DATMFORCEDRESTORING
 
     !#ifndef MPAS_EXTERNAL_ESMF_LIB
          call ESMFloc_TimeIntervalGet(interval % ti, timeString=timeString, rc=ierr)
@@ -1904,42 +1683,6 @@ module MPASAOS_timekeeping
       if (present(ierr)) then
          if (ierr == ESMFloc_SUCCESS) ierr = 0
       end if
-
-#else
-
-#ifndef MPAS_EXTERNAL_ESMF_LIB
-         call ESMF_TimeIntervalGet(interval % ti, timeString=timeString, rc=ierr)
-#else
-         !
-         ! In case an external ESMF library is being used, the time interval may be returned in
-         ! ISO period format, in which case it is easier to build a time interval string in MPAS
-         ! format given days, hours, minutes, and seconds.
-         !
-         call ESMF_TimeIntervalGet(interval % ti, StartTimeIn=StartTimeIn%t, &
-                                   d=days, h=hours, m=minutes, s_i8=seconds, sN=sn, sD=sd, rc=ierr)
-         seconds_real = real(seconds,kind=R8KIND) + (real(sn, kind=R8KIND) / real(sd, kind=R8KIND))
-
-         !
-         ! If the time interval is negative, the ESMF library will return negative values for
-         ! non-zero components of the interval, so days, hours, minutes, and seconds_real must
-         ! be checked in order to determine whether a '-' needs to be prepended to the timeString
-         !
-         neg = ''
-         if (days < 0 .or. hours < 0 .or. minutes < 0 .or. seconds_real < 0.0_R8KIND) then
-            neg = '-'
-         end if
-
-         write(timeString,'(a,i9.9,a,i2.2,a,i2.2,a,i2.2,f10.9)') trim(neg), abs(days), '_', abs(hours), ':', abs(minutes), ':', &
-                                                               int(abs(seconds_real)), abs(seconds_real) - int(abs(seconds_real))
-#endif
-
-      end if
-
-      if (present(ierr)) then
-         if (ierr == ESMF_SUCCESS) ierr = 0
-      end if
-
-#endif
 
    end subroutine mpas_get_timeInterval
 
@@ -2020,29 +1763,8 @@ module MPASAOS_timekeeping
       type (MPAS_TimeInterval_type), intent(in) :: ti
       integer (kind=I8KIND), intent(in) :: n8
 
-#ifdef DATMFORCEDRESTORING
 
         mul_ti_n8 % ti = ti % ti * n8
-
-#else
-
-#ifndef MPAS_EXTERNAL_ESMF_LIB
-        mul_ti_n8 % ti = ti % ti * n8
-#else
-        !
-        ! At present, the external ESMF library does not support multiplying a time interval
-        ! by an 8-byte integer, so we convert to a 4-byte integer whenever possible.
-        ! However, if the value of the 8-byte integer exceeds what can be represented by
-        ! a 4-byte integer, stop with a critical error.
-        !
-        if (n8 > huge(int(n8)) .or. n8 < -huge(int(n8))) then
-           call mpas_log_write('(time interval) * 64-bit integer: integer out of range for external ESMF library', &
-                               messageType=MPAS_LOG_CRIT)
-        end if
-        mul_ti_n8 % ti = ti % ti * int(n8)
-#endif
-
-#endif
 
    end function mul_ti_n8
 
@@ -2301,19 +2023,11 @@ module MPASAOS_timekeeping
       integer :: rc
       integer :: D, S, Sn, Sd
 
-#ifdef DATMFORCEDRESTORING
       call ESMFloc_TimeIntervalGet(ti % ti, D=D, S=S, Sn=Sn, Sd=Sd, rc=rc)
       D    = -D 
       S    = -S 
       Sn   = -Sn
       call ESMFloc_TimeIntervalSet(neg_ti % ti, D=D, S=S, Sn=Sn, Sd=Sd, rc=rc)
-#else
-      call ESMF_TimeIntervalGet(ti % ti, D=D, S=S, Sn=Sn, Sd=Sd, rc=rc)
-      D    = -D 
-      S    = -S 
-      Sn   = -Sn
-      call ESMF_TimeIntervalSet(neg_ti % ti, D=D, S=S, Sn=Sn, Sd=Sd, rc=rc)
-#endif
 
    end function neg_ti
 
@@ -2328,7 +2042,6 @@ module MPASAOS_timekeeping
       integer :: rc
       integer :: D, S, Sn, Sd
 
-#ifdef DATMFORCEDRESTORING
       call ESMFloc_TimeIntervalSet(zeroInterval % ti, D=0, H=0, M=0, S=0, rc=rc)
 
       if(ti < zeroInterval) then
@@ -2340,19 +2053,6 @@ module MPASAOS_timekeeping
       else
          abs_ti = ti
       end if
-#else
-      call ESMF_TimeIntervalSet(zeroInterval % ti, D=0, H=0, M=0, S=0, rc=rc)
-
-      if(ti < zeroInterval) then
-         call ESMF_TimeIntervalGet(ti % ti, D=D, S=S, Sn=Sn, Sd=Sd, rc=rc)
-         D    = -D 
-         S    = -S 
-         Sn   = -Sn
-         call ESMF_TimeIntervalSet(abs_ti % ti, D=D, S=S, Sn=Sn, Sd=Sd, rc=rc)
-      else
-         abs_ti = ti
-      end if
-#endif
 
    end function abs_ti
 

--- a/src/framework-sed/xml_stream_parser.c
+++ b/src/framework-sed/xml_stream_parser.c
@@ -49,7 +49,7 @@ struct stacknode {
 	struct stacknode *next;
 };
 
-struct stacknode *head = NULL;
+struct stacknode *MPASAOS_head = NULL;
 
 
 /*
@@ -65,7 +65,7 @@ static char *global_file;
  *  Prints an error message in a standard format.
  *
  *********************************************************************************/
-void fmt_err(const char *mesg)
+void MPASAOS_fmt_err(const char *mesg)
 {
 	char msgbuf[MSGSIZE];
 
@@ -81,7 +81,7 @@ void fmt_err(const char *mesg)
  *  Prints a warning message in a standard format.
  *
  *********************************************************************************/
-void fmt_warn(const char *mesg)
+void MPASAOS_fmt_warn(const char *mesg)
 {
 	char msgbuf[MSGSIZE];
 
@@ -96,7 +96,7 @@ void fmt_warn(const char *mesg)
  *  Prints an informational message in a standard format.
  *
  *********************************************************************************/
-void fmt_info(const char *mesg)
+void MPASAOS_fmt_info(const char *mesg)
 {
 	char msgbuf[MSGSIZE];
 
@@ -112,11 +112,11 @@ void fmt_info(const char *mesg)
  *  Pushes a new node onto the stack.
  *
  *********************************************************************************/
-void push_tag(struct stacknode *node)
+void MPASAOS_push_tag(struct stacknode *node)
 {
 	if (node != NULL) {
-		node->next = head;
-		head = node;
+		node->next = MPASAOS_head;
+		MPASAOS_head = node;
 	}
 }
 
@@ -128,13 +128,13 @@ void push_tag(struct stacknode *node)
  *  Pops a new node from the stack.
  *
  *********************************************************************************/
-struct stacknode * pop_tag(void)
+struct stacknode * MPASAOS_pop_tag(void)
 {
 	struct stacknode *retval;
 
-	retval = head;
-	if (head != NULL) {
-		head = head->next;
+	retval = MPASAOS_head;
+	if (MPASAOS_head != NULL) {
+		MPASAOS_head = MPASAOS_head->next;
 	}
 
 	return retval;
@@ -153,7 +153,7 @@ struct stacknode * pop_tag(void)
  *  is the string "stream".
  *
  *********************************************************************************/
-void parse_xml_tag_name(char *tag_buf, char *tag_name)
+void MPASAOS_parse_xml_tag_name(char *tag_buf, char *tag_name)
 {
 	size_t i;
 
@@ -191,7 +191,7 @@ void parse_xml_tag_name(char *tag_buf, char *tag_name)
  *  realtive to the starting position.
  *
  *********************************************************************************/
-size_t parse_xml_tag(char *xml_buf, size_t buf_len, char *tag, size_t *tag_len, int *line, int *start_line)
+size_t MPASAOS_parse_xml_tag(char *xml_buf, size_t buf_len, char *tag, size_t *tag_len, int *line, int *start_line)
 {
 	size_t i, j;
 	int found_end, block_comment;
@@ -284,7 +284,7 @@ size_t parse_xml_tag(char *xml_buf, size_t buf_len, char *tag, size_t *tag_len, 
  *  all MPI tasks that belong to the communicator.
  *
  *********************************************************************************/
-int par_read(char *fname, int *mpi_comm, char **xml_buf, size_t *bufsize)
+int MPASAOS_par_read(char *fname, int *mpi_comm, char **xml_buf, size_t *bufsize)
 {
 	int iofd;
 	int rank;
@@ -345,7 +345,7 @@ int par_read(char *fname, int *mpi_comm, char **xml_buf, size_t *bufsize)
  *  are consistent.
  *
  *********************************************************************************/
-int attribute_check(ezxml_t stream)
+int MPASAOS_attribute_check(ezxml_t stream)
 {
 	const char *s_name, *s_type, *s_filename, *s_filename_intv, *s_input, *s_output, *s_ref_time;
 	char msgbuf[MSGSIZE];
@@ -364,17 +364,17 @@ int attribute_check(ezxml_t stream)
 	 *  Check for required attributes
 	 */
 	if (s_name == NULL) {
-		fmt_err("stream must have the \"name\" attribute.");
+		MPASAOS_fmt_err("stream must have the \"name\" attribute.");
 		return 1;
 	}
 	else if (s_type == NULL) {
 		snprintf(msgbuf, MSGSIZE, "stream \"%s\" must have the \"type\" attribute.", s_name);
-		fmt_err(msgbuf);
+		MPASAOS_fmt_err(msgbuf);
 		return 1;
 	}
 	else if (s_filename == NULL) {
 		snprintf(msgbuf, MSGSIZE, "stream \"%s\" must have the \"filename_template\" attribute.", s_name);
-		fmt_err(msgbuf);
+		MPASAOS_fmt_err(msgbuf);
 		return 1;
 	}
 
@@ -384,21 +384,21 @@ int attribute_check(ezxml_t stream)
 	 */
 	if (strstr(s_type, "input") != NULL && s_input == NULL) {
 		snprintf(msgbuf, MSGSIZE, "stream \"%s\" is an input stream and must have the \"input_interval\" attribute.", s_name);
-		fmt_err(msgbuf);
+		MPASAOS_fmt_err(msgbuf);
 		return 1;
 	}
 	if (strstr(s_type, "output") != NULL && s_output == NULL) {
 		snprintf(msgbuf, MSGSIZE, "stream \"%s\" is an output stream and must have the \"output_interval\" attribute.", s_name);
-		fmt_err(msgbuf);
+		MPASAOS_fmt_err(msgbuf);
 		return 1;
 	}
 	if (strstr(s_type, "input") != NULL && strstr(s_type, "output") == NULL && s_output != NULL) {
 		snprintf(msgbuf, MSGSIZE, "input-only stream \"%s\" has the \"output_interval\" attribute.", s_name);
-		fmt_warn(msgbuf);
+		MPASAOS_fmt_warn(msgbuf);
 	}
 	if (strstr(s_type, "output") != NULL && strstr(s_type, "input") == NULL && s_input != NULL) {
 		snprintf(msgbuf, MSGSIZE, "output-only stream \"%s\" has the \"input_interval\" attribute.", s_name);
-		fmt_warn(msgbuf);
+		MPASAOS_fmt_warn(msgbuf);
 	}
 
 	/*
@@ -407,32 +407,32 @@ int attribute_check(ezxml_t stream)
 	if ( s_filename_intv != NULL ) {
 		if ( strstr(s_filename_intv, "input_interval") != NULL && s_input == NULL) {
 			snprintf(msgbuf, MSGSIZE, "stream \"%s\" has a value of \"input_interval\" for the \"filename_interval\" attribute, without defining the \"input_interval\" attribute.", s_name);
-			fmt_err(msgbuf);
+			MPASAOS_fmt_err(msgbuf);
 			return 1;
 		}
 		if ( strstr(s_filename_intv, "output_interval") != NULL && s_output == NULL) {
 			snprintf(msgbuf, MSGSIZE, "stream \"%s\" has a value of \"output_interval\" for the \"filename_interval\" attribute, without defining the \"output_interval\" attribute.", s_name);
-			fmt_err(msgbuf);
+			MPASAOS_fmt_err(msgbuf);
 			return 1;
 		}
 		if ( strstr(s_filename_intv, "input_interval") != NULL && strstr(s_input, "initial_only") != NULL) {
 			snprintf(msgbuf, MSGSIZE, "stream \"%s\" cannot have a value of \"input_interval\" for the \"filename_interval\" attribute, when \"input_interval\" is set to \"initial_only\".", s_name);
-			fmt_err(msgbuf);
+			MPASAOS_fmt_err(msgbuf);
 			return 1;
 		}
 		if ( strstr(s_filename_intv, "output_interval") != NULL && strstr(s_output, "initial_only") != NULL) {
 			snprintf(msgbuf, MSGSIZE, "stream \"%s\" cannot have a value of \"output_interval\" for the \"filename_interval\" attribute, when \"output_interval\" is set to \"initial_only\".", s_name);
-			fmt_err(msgbuf);
+			MPASAOS_fmt_err(msgbuf);
 			return 1;
 		}
 		if ( strstr(s_filename_intv, "input_interval") != NULL && strstr(s_input, "final_only") != NULL) {
 			snprintf(msgbuf, MSGSIZE, "stream \"%s\" cannot have a value of \"input_interval\" for the \"filename_interval\" attribute, when \"input_interval\" is set to \"final_only\".", s_name);
-			fmt_err(msgbuf);
+			MPASAOS_fmt_err(msgbuf);
 			return 1;
 		}
 		if ( strstr(s_filename_intv, "output_interval") != NULL && strstr(s_output, "final_only") != NULL) {
 			snprintf(msgbuf, MSGSIZE, "stream \"%s\" cannot have a value of \"output_interval\" for the \"filename_interval\" attribute, when \"output_interval\" is set to \"final_only\".", s_name);
-			fmt_err(msgbuf);
+			MPASAOS_fmt_err(msgbuf);
 			return 1;
 		}
 	}
@@ -449,7 +449,7 @@ int attribute_check(ezxml_t stream)
 		if (s_filename[i] == '$') {
 			if (strchr("YMDdhmsGSB",nextchar) == NULL) {
 				snprintf(msgbuf, MSGSIZE, "filename_template for stream \"%s\" contains unrecognized variable \"$%c\".", s_name, nextchar);
-				fmt_err(msgbuf);
+				MPASAOS_fmt_err(msgbuf);
 				return 1;
 			}
 		}	
@@ -466,7 +466,7 @@ int attribute_check(ezxml_t stream)
  *  Checks that two streams have unique name and filename_template attributes
  *
  *********************************************************************************/
-int uniqueness_check(ezxml_t stream1, ezxml_t stream2)
+int MPASAOS_uniqueness_check(ezxml_t stream1, ezxml_t stream2)
 {
 	const char *name, *name2;
 	const char *filename, *filename2;
@@ -483,13 +483,13 @@ int uniqueness_check(ezxml_t stream1, ezxml_t stream2)
 
 		if (strcmp(name, name2) == 0) {
 			snprintf(msgbuf, MSGSIZE, "stream \"%s\" is define more than once.", name);
-			fmt_err(msgbuf);
+			MPASAOS_fmt_err(msgbuf);
 			return 1;
 		}
 		if (strstr(type, "output") != NULL || strstr(type2, "output") != NULL){
 			if (strcmp(filename, filename2) == 0) {
 				snprintf(msgbuf, MSGSIZE, "Output streams \"%s\" and \"%s\" cannot share the filename_template \"%s\".", name, name2, filename);
-				fmt_err(msgbuf);
+				MPASAOS_fmt_err(msgbuf);
 				return 1;
 			}
 		}
@@ -506,7 +506,7 @@ int uniqueness_check(ezxml_t stream1, ezxml_t stream2)
  *  Validates the specification of run-time streams.
  *
  *********************************************************************************/
-int check_streams(ezxml_t streams)
+int MPASAOS_check_streams(ezxml_t streams)
 {
 	ezxml_t stream_xml;
 	ezxml_t stream2_xml;
@@ -519,7 +519,7 @@ int check_streams(ezxml_t streams)
 
 	/* Check immutable streams */
 	for (stream_xml = ezxml_child(streams, "immutable_stream"); stream_xml; stream_xml = ezxml_next(stream_xml)) {
-		if (attribute_check(stream_xml) != 0) {
+		if (MPASAOS_attribute_check(stream_xml) != 0) {
 			return 1;
 		}	
 
@@ -529,7 +529,7 @@ int check_streams(ezxml_t streams)
 		if (test_xml != NULL || test2_xml != NULL) {
 			name = ezxml_attr(stream_xml, "name");
 			snprintf(msgbuf, MSGSIZE, "the set of variables in stream \"%s\" cannot be modified.", name);
-			fmt_err(msgbuf);
+			MPASAOS_fmt_err(msgbuf);
 			return 1;
 		}
 	}
@@ -538,7 +538,7 @@ int check_streams(ezxml_t streams)
 	for (stream_xml = ezxml_child(streams, "stream"); stream_xml; stream_xml = ezxml_next(stream_xml)) {
 		name = ezxml_attr(stream_xml, "name");
 
-		if (attribute_check(stream_xml) != 0) {
+		if (MPASAOS_attribute_check(stream_xml) != 0) {
 			return 1;
 		}	
 
@@ -548,7 +548,7 @@ int check_streams(ezxml_t streams)
 /* TODO: should this also be done only on the master task? */
 			if (access(filename, F_OK|R_OK) == -1) {
 				snprintf(msgbuf, MSGSIZE, "definition of stream \"%s\" references file %s that cannot be opened for reading.", name, filename);
-				fmt_err(msgbuf);
+				MPASAOS_fmt_err(msgbuf);
 				return 1;
 			}
 		}
@@ -558,18 +558,18 @@ int check_streams(ezxml_t streams)
 	/* Check that the name and filename_template attributes of all streams are unique */
 	for (stream_xml = ezxml_child(streams, "stream"); stream_xml; stream_xml = ezxml_next(stream_xml)) {
 		for (stream2_xml = ezxml_child(streams, "stream"); stream2_xml; stream2_xml = ezxml_next(stream2_xml)) {
-			if (uniqueness_check(stream_xml, stream2_xml)) return 1;
+			if (MPASAOS_uniqueness_check(stream_xml, stream2_xml)) return 1;
 		}
 		for (stream2_xml = ezxml_child(streams, "immutable_stream"); stream2_xml; stream2_xml = ezxml_next(stream2_xml)) {
-			if (uniqueness_check(stream_xml, stream2_xml)) return 1;
+			if (MPASAOS_uniqueness_check(stream_xml, stream2_xml)) return 1;
 		}
 	}
 	for (stream_xml = ezxml_child(streams, "immutable_stream"); stream_xml; stream_xml = ezxml_next(stream_xml)) {
 		for (stream2_xml = ezxml_child(streams, "stream"); stream2_xml; stream2_xml = ezxml_next(stream2_xml)) {
-			if (uniqueness_check(stream_xml, stream2_xml)) return 1;
+			if (MPASAOS_uniqueness_check(stream_xml, stream2_xml)) return 1;
 		}
 		for (stream2_xml = ezxml_child(streams, "immutable_stream"); stream2_xml; stream2_xml = ezxml_next(stream2_xml)) {
-			if (uniqueness_check(stream_xml, stream2_xml)) return 1;
+			if (MPASAOS_uniqueness_check(stream_xml, stream2_xml)) return 1;
 		}
 	}
 
@@ -593,7 +593,7 @@ int check_streams(ezxml_t streams)
  *  with a well-specified grammar.
  *
  *********************************************************************************/
-int xml_syntax_check(char *xml_buf, size_t bufsize)
+int MPASAOS_xml_syntax_check(char *xml_buf, size_t bufsize)
 {
 	size_t i;
 	size_t len;
@@ -616,7 +616,7 @@ int xml_syntax_check(char *xml_buf, size_t bufsize)
 
 	if ( xml_buf[0] == '>' ) {
 		snprintf(msgbuf, MSGSIZE, "line %i, unexpected starting \'>\' character. A file cannot start with a  \'>\' character.", line);
-		fmt_err(msgbuf);
+		MPASAOS_fmt_err(msgbuf);
 		return 1;
 	}
 
@@ -626,18 +626,18 @@ int xml_syntax_check(char *xml_buf, size_t bufsize)
 				nleftcom++;
 				if (nleftcom - nrightcom > 1) {
 					snprintf(msgbuf, MSGSIZE, "line %i, unexpected XML comment open. Is the previous XML comment missing a \'-->\'?", line);
-					fmt_err(msgbuf);
+					MPASAOS_fmt_err(msgbuf);
 					return 1;
 				} else if (nleft != nright) {
 					snprintf(msgbuf, MSGSIZE, "line %i, unexpected XML comment open. Is the previous XML tag missing a \'>\'?\n   NOTE: Comments are not allowed within an open XML tag.", line);
-					fmt_err(msgbuf);
+					MPASAOS_fmt_err(msgbuf);
 					return 1;
 				}
 			} else {
 				nleft++;
 				if (nleft - nright > 1){
 					snprintf(msgbuf, MSGSIZE, "line %i, unexpected \'<\' character. Is the previous XML tag missing a \'>\'?", line);
-					fmt_err(msgbuf);
+					MPASAOS_fmt_err(msgbuf);
 					return 1;
 				}
 			}
@@ -647,18 +647,18 @@ int xml_syntax_check(char *xml_buf, size_t bufsize)
 				nrightcom++;
 				if (nleftcom != nrightcom) {
 					snprintf(msgbuf, MSGSIZE, "line %i, unexpected XML comment close. Is the XML comment missing a \'<!--\'?", line);
-					fmt_err(msgbuf);
+					MPASAOS_fmt_err(msgbuf);
 					return 1;
 				} else if (nleft != nright) {
 					snprintf(msgbuf, MSGSIZE, "line %i, unexpected XML comment close. Is the previous XML tag missing a \'>\'?\n   NOTE: Comments are not allowed within an open XML tag.", line);
-					fmt_err(msgbuf);
+					MPASAOS_fmt_err(msgbuf);
 					return 1;
 				}
 			} else {
 				nright++;
 				if (nleft != nright) {
 					snprintf(msgbuf, MSGSIZE, "line %i, unexpected \'>\' character. Is the XML tag missing a \'<\'?", line);
-					fmt_err(msgbuf);
+					MPASAOS_fmt_err(msgbuf);
 					return 1;
 				}
 			}
@@ -668,7 +668,7 @@ int xml_syntax_check(char *xml_buf, size_t bufsize)
 		}
 	}
 	if (nleft != nright) {				  /* Probably only triggered if no final '>' character? */
-		fmt_err("unbalanced angle brackets in XML. Is the file missing a final \'>\'?");
+		MPASAOS_fmt_err("unbalanced angle brackets in XML. Is the file missing a final \'>\'?");
 		return 1;
 	}
 
@@ -691,7 +691,7 @@ int xml_syntax_check(char *xml_buf, size_t bufsize)
 		if (xml_buf[i] == '=' || xml_buf[i] == '\n') {
 			if (nleft != 0) {
 				snprintf(msgbuf, MSGSIZE, "line %i, unterminated string. Is a closing quote not present?", line);
-				fmt_err(msgbuf);
+				MPASAOS_fmt_err(msgbuf);
 				return 1;
 			}
 			if (xml_buf[i] == '\n') {
@@ -700,7 +700,7 @@ int xml_syntax_check(char *xml_buf, size_t bufsize)
 		}
 	}
 	if (nleft != 0) {
-		fmt_err("unbalanced quotes in XML.");
+		MPASAOS_fmt_err("unbalanced quotes in XML.");
 		return 1;
 	}
 
@@ -713,7 +713,7 @@ int xml_syntax_check(char *xml_buf, size_t bufsize)
 
 	line = 1;
 	do {
-		i += parse_xml_tag(&xml_buf[i], (bufsize - i), tag_buf, &len, &line, &start_line);
+		i += MPASAOS_parse_xml_tag(&xml_buf[i], (bufsize - i), tag_buf, &len, &line, &start_line);
 
 		if (len > 0) {
 
@@ -724,21 +724,21 @@ int xml_syntax_check(char *xml_buf, size_t bufsize)
 			/* An opening tag. Push it onto the stack... */
 			else if (tag_buf[0] != '/' && tag_buf[len-1] != '/') {
 				node = (struct stacknode *)malloc(sizeof(struct stacknode));
-				parse_xml_tag_name(tag_buf, node->name);
+				MPASAOS_parse_xml_tag_name(tag_buf, node->name);
 				node->line = start_line;
-				push_tag(node);
+				MPASAOS_push_tag(node);
 			}
 			/* A closing tag. Pop the stack... */
 			else if (tag_buf[0] == '/' && tag_buf[len-1] != '/') {
-				node = pop_tag();
-				parse_xml_tag_name(&tag_buf[1], tmp_node.name);    /* NB: &tag_buf[1] to skip over '/' character */
+				node = MPASAOS_pop_tag();
+				MPASAOS_parse_xml_tag_name(&tag_buf[1], tmp_node.name);    /* NB: &tag_buf[1] to skip over '/' character */
 				if (strncmp(tmp_node.name, node->name, (size_t)MSGSIZE) != 0) {
 					snprintf(msgbuf, MSGSIZE, "Found unexpected closing tag \"%s\" at line %i.", tmp_node.name, start_line);
-					fmt_err(msgbuf);
+					MPASAOS_fmt_err(msgbuf);
 					snprintf(msgbuf, MSGSIZE, "line %i, unclosed or badly nested XML tag \"%s\".", node->line, node->name);
-					fmt_err(msgbuf);
+					MPASAOS_fmt_err(msgbuf);
 
-					while ((node = pop_tag()) != NULL)
+					while ((node = MPASAOS_pop_tag()) != NULL)
 						free(node);
 					return 1;	
 				}
@@ -746,7 +746,7 @@ int xml_syntax_check(char *xml_buf, size_t bufsize)
 			}
 			/* A singleton tag. Life is simple... */
 			else if (tag_buf[0] != '/' && tag_buf[len-1] == '/') {
-				parse_xml_tag_name(tag_buf, tmp_node.name);
+				MPASAOS_parse_xml_tag_name(tag_buf, tmp_node.name);
 
 			}
 			/* Probable syntax error? */
@@ -759,12 +759,12 @@ int xml_syntax_check(char *xml_buf, size_t bufsize)
 	} while (i <= bufsize && len > 0);
 
 	/* Pop the rest of the stack for any unclosed tags */
-	node = pop_tag();
+	node = MPASAOS_pop_tag();
 	if (node != NULL) {
 		snprintf(msgbuf, MSGSIZE, "line %i, unclosed or badly nested XML tag \"%s\".", node->line, node->name);
-		fmt_err(msgbuf);
+		MPASAOS_fmt_err(msgbuf);
 		
-		while ((node = pop_tag()) != NULL)
+		while ((node = MPASAOS_pop_tag()) != NULL)
 			free(node);
 		return 1;	
 	}
@@ -784,7 +784,7 @@ int xml_syntax_check(char *xml_buf, size_t bufsize)
  *  in the template already exists but is not writable, a non-zero error is returned.
  *
  *********************************************************************************/
-int build_stream_path(const char *stream, const char *template, int *mpi_comm)
+int MPASAOS_build_stream_path(const char *stream, const char *template, int *mpi_comm)
 {
 	char *filename_path;
 	char *directory;
@@ -841,7 +841,7 @@ int build_stream_path(const char *stream, const char *template, int *mpi_comm)
 							}
 						} else if ( !writable_parent ) {
 							snprintf(msgbuf, MSGSIZE, "cannot create directory %s needed by stream \"%s\": parent directory is not writable.", directory, stream);
-							fmt_err(msgbuf);
+							MPASAOS_fmt_err(msgbuf);
 							free(filename_path);
 							free(directory);
 							writable_parent = 0;
@@ -864,7 +864,7 @@ int build_stream_path(const char *stream, const char *template, int *mpi_comm)
 				/* directory exists, need to check permissions */
 				if (access(filename_path, W_OK) != 0) {
 					snprintf(msgbuf, MSGSIZE, "definition of stream \"%s\" references directory %s without write permission.", stream, filename_path);
-					fmt_err(msgbuf);
+					MPASAOS_fmt_err(msgbuf);
 					free(filename_path);
 					free(directory);
 	
@@ -877,7 +877,7 @@ int build_stream_path(const char *stream, const char *template, int *mpi_comm)
 			}
 			else if ( !writable_parent ) {
 					snprintf(msgbuf, MSGSIZE, "cannot create directory %s needed by stream \"%s\": parent directory is not writable.", directory, stream);
-					fmt_err(msgbuf);
+					MPASAOS_fmt_err(msgbuf);
 					free(filename_path);
 					free(directory);
 					writable_parent = 0;
@@ -931,7 +931,7 @@ int build_stream_path(const char *stream, const char *template, int *mpi_comm)
  *  function returns 0.
  *
  *********************************************************************************/
-int extract_stream_interval(const char *interval, const char *interval_type, const char **interval2, const char *streamID, ezxml_t streams)
+int MPASAOS_extract_stream_interval(const char *interval, const char *interval_type, const char **interval2, const char *streamID, ezxml_t streams)
 {
 	int i;
 	int stream_found, copy_start, copy_from, copy_to;
@@ -1036,7 +1036,7 @@ int extract_stream_interval(const char *interval, const char *interval_type, con
  *  and mpi_comm is the Fortran MPI communicator used by MPAS.
  *
  *********************************************************************************/
-void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
+void MPASAOS_xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 {
 	char *xml_buf;
 	size_t bufsize;
@@ -1085,7 +1085,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 	*status = 0;
 
 	global_file = fname;
-	if (par_read(fname, mpi_comm, &xml_buf, &bufsize) != 0) {
+	if (MPASAOS_par_read(fname, mpi_comm, &xml_buf, &bufsize) != 0) {
 		*status = 1;
 		return;
 	}
@@ -1122,7 +1122,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 		/* Extract the input interval, if it refer to other streams */
 		if ( interval_in ) {
 			sprintf(interval_type, "input_interval");
-			*status = extract_stream_interval(interval_in, interval_type, &interval_in2, streamID, streams);
+			*status = MPASAOS_extract_stream_interval(interval_in, interval_type, &interval_in2, streamID, streams);
 			if ( *status != 0 ) {
 				return;
 			}
@@ -1131,7 +1131,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 		/* Extract the output interval, if it refer to other streams */
 		if ( interval_out ) {
 			sprintf(interval_type, "output_interval");
-			*status = extract_stream_interval(interval_out, interval_type, &interval_out2, streamID, streams);
+			*status = MPASAOS_extract_stream_interval(interval_out, interval_type, &interval_out2, streamID, streams);
 			if ( *status != 0 ) {
 				return;
 			}
@@ -1351,7 +1351,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 
 		/* For output streams, build the directory structure where files will be written */
 		if (itype == 2 || itype == 3) {
-			err = build_stream_path(streamID, filename_template, mpi_comm);
+			err = MPASAOS_build_stream_path(streamID, filename_template, mpi_comm);
 			if (err != 0) {
 				*status = 1;
 				return;
@@ -1406,7 +1406,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 			MPASAOS_stream_mgr_add_pkg_c(manager, streamID, package, &err);
 			if (err != 0) {
 				snprintf(msgbuf, MSGSIZE, "definition of stream \"%s\" references unrecognized package \"%s\".", streamID, package);
-				fmt_warn(msgbuf);
+				MPASAOS_fmt_warn(msgbuf);
 			}
 			else {
 				snprintf(msgbuf, MSGSIZE, "        %-20s%s\n", "package:", package);
@@ -1417,7 +1417,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 				MPASAOS_stream_mgr_add_pkg_c(manager, streamID, package, &err);
 				if (err != 0) {
 					snprintf(msgbuf, MSGSIZE, "definition of stream \"%s\" references unrecognized package \"%s\".", streamID, package);
-					fmt_warn(msgbuf);
+					MPASAOS_fmt_warn(msgbuf);
 				}
 				else {
 					snprintf(msgbuf, MSGSIZE, "        %-20s%s", "package:", package);
@@ -1451,7 +1451,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 		/* Extract the input interval, if it refer to other streams */
 		if ( interval_in ) {
 			sprintf(interval_type, "input_interval");
-			*status = extract_stream_interval(interval_in, interval_type, &interval_in2, streamID, streams);
+			*status = MPASAOS_extract_stream_interval(interval_in, interval_type, &interval_in2, streamID, streams);
 			if ( *status != 0 ) {
 				return;
 			}
@@ -1460,7 +1460,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 		/* Extract the output interval, if it refer to other streams */
 		if ( interval_out ) {
 			sprintf(interval_type, "output_interval");
-			*status = extract_stream_interval(interval_out, interval_type, &interval_out2, streamID, streams);
+			*status = MPASAOS_extract_stream_interval(interval_out, interval_type, &interval_out2, streamID, streams);
 			if ( *status != 0 ) {
 				return;
 			}
@@ -1681,7 +1681,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 
 		/* For output streams, build the directory structure where files will be written */
 		if (itype == 2 || itype == 3) {
-			err = build_stream_path(streamID, filename_template, mpi_comm);
+			err = MPASAOS_build_stream_path(streamID, filename_template, mpi_comm);
 			if (err != 0) {
 				*status = 1;
 				return;
@@ -1736,7 +1736,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 			MPASAOS_stream_mgr_add_pkg_c(manager, streamID, package, &err);
 			if (err != 0) {
 				snprintf(msgbuf, MSGSIZE, "definition of stream \"%s\" references unrecognized package \"%s\".", streamID, package);
-				fmt_warn(msgbuf);
+				MPASAOS_fmt_warn(msgbuf);
 			}
 			else {
 				snprintf(msgbuf, MSGSIZE, "        %-20s%s", "package:", package);
@@ -1747,7 +1747,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 				MPASAOS_stream_mgr_add_pkg_c(manager, streamID, package, &err);
 				if (err != 0) {
 					snprintf(msgbuf, MSGSIZE, "definition of stream \"%s\" references unrecognized package \"%s\".", streamID, package);
-					fmt_warn(msgbuf);
+					MPASAOS_fmt_warn(msgbuf);
 				}
 				else {
 					snprintf(msgbuf, MSGSIZE, "        %-20s%s", "package:", package);
@@ -1782,7 +1782,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
 			}
 			else {
 				snprintf(msgbuf, MSGSIZE, "definition of stream \"%s\" references file %s that cannot be opened for reading.", streamID, varfile);
-				fmt_err(msgbuf);
+				MPASAOS_fmt_err(msgbuf);
 				*status = 1;
 				return;
 			}
@@ -1910,7 +1910,7 @@ void xml_stream_parser(char *fname, void *manager, int *mpi_comm, int *status)
  *  definitions, and mpi_comm is the Fortran MPI communicator used by MPAS.
  *
  *********************************************************************************/
-void xml_stream_get_attributes(char *fname, char *streamname, int *mpi_comm, char *filename, char *ref_time, char *filename_interval, char *io_type, int *status)
+void MPASAOS_xml_stream_get_attributes(char *fname, char *streamname, int *mpi_comm, char *filename, char *ref_time, char *filename_interval, char *io_type, int *status)
 {
 	char *xml_buf;
 	size_t bufsize;
@@ -1923,12 +1923,12 @@ void xml_stream_get_attributes(char *fname, char *streamname, int *mpi_comm, cha
 	*status = 0;
 
 	global_file = fname;
-	if (par_read(fname, mpi_comm, &xml_buf, &bufsize) != 0) {
+	if (MPASAOS_par_read(fname, mpi_comm, &xml_buf, &bufsize) != 0) {
 		*status = 1;
 		return;
 	}
 
-	if (xml_syntax_check(xml_buf, bufsize) != 0) {
+	if (MPASAOS_xml_syntax_check(xml_buf, bufsize) != 0) {
 		*status = 1;
 		return;
 	}
@@ -1941,7 +1941,7 @@ void xml_stream_get_attributes(char *fname, char *streamname, int *mpi_comm, cha
 		return;
 	}	
 
-	if (check_streams(streams) != 0) {
+	if (MPASAOS_check_streams(streams) != 0) {
 		*status = 1;
 		return;
 	}

--- a/src/framework/mpas_timekeeping_types.inc
+++ b/src/framework/mpas_timekeeping_types.inc
@@ -12,19 +12,11 @@
                          MPAS_360DAY = 2
 
    type MPAS_Time_type
-#ifdef DATMFORCEDRESTORING
       type (ESMFloc_Time) :: t
-#else
-      type (ESMF_Time) :: t
-#endif
    end type
 
    type MPAS_TimeInterval_type
-#ifdef DATMFORCEDRESTORING
       type (ESMFloc_TimeInterval) :: ti
-#else
-      type (ESMF_TimeInterval) :: ti
-#endif
    end type
 
    type MPAS_Alarm_type
@@ -40,11 +32,7 @@
    type MPAS_Clock_type
       integer :: direction
       integer :: nAlarms
-#ifdef DATMFORCEDRESTORING
       type (ESMFloc_Clock) :: c
-#else
-      type (ESMF_Clock) :: c
-#endif
       type (MPAS_Alarm_type), pointer :: alarmListHead => null()
    end type
 

--- a/src/framework/mpas_timekeeping_types.inc
+++ b/src/framework/mpas_timekeeping_types.inc
@@ -12,11 +12,19 @@
                          MPAS_360DAY = 2
 
    type MPAS_Time_type
+#ifdef DATMFORCEDRESTORING
+      type (ESMFloc_Time) :: t
+#else
       type (ESMF_Time) :: t
+#endif
    end type
 
    type MPAS_TimeInterval_type
+#ifdef DATMFORCEDRESTORING
+      type (ESMFloc_TimeInterval) :: ti
+#else
       type (ESMF_TimeInterval) :: ti
+#endif
    end type
 
    type MPAS_Alarm_type
@@ -32,7 +40,11 @@
    type MPAS_Clock_type
       integer :: direction
       integer :: nAlarms
+#ifdef DATMFORCEDRESTORING
+      type (ESMFloc_Clock) :: c
+#else
       type (ESMF_Clock) :: c
+#endif
       type (MPAS_Alarm_type), pointer :: alarmListHead => null()
    end type
 


### PR DESCRIPTION
Merge branch update/ocean3p75

This is a collection of commits that do the following:
Defaults have been added/updated for higher (15km, 7.5km and 3.75km) resolutions.
Diagnostic output defaults have been added to better align ocean and seaice diagnostic files with month boundaries. This reduces data loss at a restart.
Ocean gpu code can be built and run. However, the gpu solution is different from the cpu solution and needs further debugging.
Ocean surface salinity forcing has been merged into one ocean code base. Ocean and seaice time managers now no longer use the ESMF library, but use esmf-emulating code E3SM provided with the code.

Components part of this PR:
ccs_config
cime
mpas-ocean 
mpas-seaice
mpas-framework
