### PR TITLE
OpenACC changes to the pool routines, dmpar routine, and Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,16 +155,16 @@ pgi-summit:
 	"CC_SERIAL = pgcc" \
 	"CXX_SERIAL = pgc++" \
 	"FFLAGS_PROMOTION = -r8" \
-	"FFLAGS_OPT = -g -O3 -byteswapio -Mfree" \
+	"FFLAGS_OPT = -O4 -gopt -byteswapio -Mfree -Mnosave -Mrecursive -Mstack_arrays -DMPAS_NVTX_RANGES" \
 	"CFLAGS_OPT = -O3 " \
 	"CXXFLAGS_OPT = -O3 " \
-	"LDFLAGS_OPT = -O3 " \
-	"FFLAGS_ACC = -acc -Minfo=accel -ta=tesla:cc70,cc60,deepcopy,nollvm " \
-	"CFLAGS_ACC = -acc -Minfo=accel -ta=tesla:cc70,cc60,deepcopy,nollvm "  \
-	"FFLAGS_DEBUG = -O0 -g -Mbounds -Mchkptr -byteswapio -Mfree -Ktrap=divz,fp,inv,ovf -traceback" \
+	"LDFLAGS_OPT = -O3 -lnvhpcwrapnvtx" \
+	"FFLAGS_ACC = -acc=gpu -Minfo=acc -gpu=lineinfo,ccnative,safecache -cudalib=cublas " \
+	"CFLAGS_ACC = -acc=gpu -Minfo=acc -gpu=lineinfo,ccnative,safecache -cudalib=cublas " \
+	"FFLAGS_DEBUG = -O0 -g -Mbounds -Mchkptr -byteswapio -Mfree -Ktrap=divz,fp,inv,ovf -traceback -Mnosave -Mrecursive -DMPAS_NVTX_RANGES" \
 	"CFLAGS_DEBUG = -O0 -g -traceback" \
 	"CXXFLAGS_DEBUG = -O0 -g -traceback" \
-	"LDFLAGS_DEBUG = -O0 -g -Mbounds -Mchkptr -Ktrap=divz,fp,inv,ovf -traceback" \
+	"LDFLAGS_DEBUG = -O0 -g -Mbounds -Mchkptr -Ktrap=divz,fp,inv,ovf -traceback -lnvhpcwrapnvtx" \
 	"FFLAGS_OMP = -mp" \
 	"CFLAGS_OMP = -mp" \
 	"PICFLAG = -fpic" \
@@ -593,7 +593,7 @@ ifneq ($(wildcard $(PIO)/lib), )
 else
 	PIO_LIB = $(PIO)
 endif
-LIBS = -L$(PIO_LIB)
+LIBS += -L$(PIO_LIB)
 
 #
 # Regardless of PIO library version, look for an include subdirectory of PIO path
@@ -681,6 +681,24 @@ endif
 	LIBS += -llapack
 	LIBS += -lblas
 	override CPPFLAGS += -DUSE_LAPACK
+endif
+
+ifeq "$(USE_CUBLAS)" "true"
+ifndef CUBLAS
+$(error CUBLAS is not set.  Please set CUBLAS to the cuBLAS install directory when USE_CUBLAS=true)
+endif
+ifneq ($(wildcard $(CUBLAS)/libcublas.*), )
+	LIBS += -L$(CUBLAS)
+else ifneq ($(wildcard $(CUBLAS)/lib/libcublas.*), )
+	LIBS += -L$(CUBLAS)/lib
+else ifneq ($(wildcard $(CUBLAS)/lib64/libcublas.*), )
+	LIBS += -L$(CUBLAS)/lib64
+else
+$(error libcublas.* does NOT exist in $(CUBLAS) or $(CUBLAS)/lib or $(CUBLAS)/lib64)
+endif
+	LIBS += -lcublas
+	FCINCLUDES += -I$(CUBLAS)/include
+	override CPPFLAGS += -DUSE_CUBLAS
 endif
 
 RM = rm -f
@@ -866,6 +884,12 @@ ifeq "$(OPENACC)" "true"
 	OPENACC_MESSAGE="MPAS was built with OpenACC accelerator support enabled."
 else
 	OPENACC_MESSAGE="MPAS was built without OpenACC accelerator support."
+endif
+
+ifeq "$(USE_CUBLAS)" "true"
+	CUBLAS_MESSAGE="MPAS was built with cuBLAS support enabled."
+else
+	CUBLAS_MESSAGE="MPAS was built without cuBLAS support."
 endif
 
 ifneq ($(wildcard .mpas_core_*), ) # CHECK FOR BUILT CORE
@@ -1096,6 +1120,7 @@ endif
 	@echo $(OPENMP_MESSAGE)
 	@echo $(OPENMP_OFFLOAD_MESSAGE)
 	@echo $(OPENACC_MESSAGE)
+	@echo $(CUBLAS_MESSAGE)
 	@echo $(SHAREDLIB_MESSAGE)
 ifeq "$(AUTOCLEAN)" "true"
 	@echo $(AUTOCLEAN_MESSAGE)
@@ -1103,6 +1128,7 @@ endif
 	@echo $(GEN_F90_MESSAGE)
 	@echo $(TIMER_MESSAGE)
 	@echo $(PIO_MESSAGE)
+	@echo $(GOTM_MESSAGE)
 	@echo "*******************************************************************************"
 clean:
 	cd $(FWPATH); $(MAKE) clean RM="$(RM)" CORE="$(CORE)"
@@ -1174,8 +1200,9 @@ errmsg:
 	@echo "    PRECISION=single - builds with default single-precision real kind. Default is to use double-precision."
 	@echo "    SHAREDLIB=true - generate position-independent code suitable for use in a shared library. Default is false."
 	@echo "    USE_LAPACK=true - builds and links with LAPACK / BLAS libraries.  Default is to not use LAPACK."
+	@echo "    USE_CUBLAS=true - builds and links with cuBLAS libraries.  Default is to not use cuBLAS."
 	@echo ""
-	@echo "Ensure that NETCDF, PNETCDF, PIO, LAPACK (if USE_LAPACK=true), and PAPI (if USE_PAPI=true) are environment variables"
+	@echo "Ensure that NETCDF, PNETCDF, PIO, LAPACK (if USE_LAPACK=true), cuBLAS (if USE_CUBLAS=true) and PAPI (if USE_PAPI=true) are environment variables"
 	@echo "that point to the absolute paths for the libraries."
 	@echo ""
 ifdef CORE

--- a/Makefile
+++ b/Makefile
@@ -683,24 +683,6 @@ endif
 	override CPPFLAGS += -DUSE_LAPACK
 endif
 
-ifeq "$(USE_CUBLAS)" "true"
-ifndef CUBLAS
-$(error CUBLAS is not set.  Please set CUBLAS to the cuBLAS install directory when USE_CUBLAS=true)
-endif
-ifneq ($(wildcard $(CUBLAS)/libcublas.*), )
-	LIBS += -L$(CUBLAS)
-else ifneq ($(wildcard $(CUBLAS)/lib/libcublas.*), )
-	LIBS += -L$(CUBLAS)/lib
-else ifneq ($(wildcard $(CUBLAS)/lib64/libcublas.*), )
-	LIBS += -L$(CUBLAS)/lib64
-else
-$(error libcublas.* does NOT exist in $(CUBLAS) or $(CUBLAS)/lib or $(CUBLAS)/lib64)
-endif
-	LIBS += -lcublas
-	FCINCLUDES += -I$(CUBLAS)/include
-	override CPPFLAGS += -DUSE_CUBLAS
-endif
-
 RM = rm -f
 CPP = cpp -P -traditional
 RANLIB = ranlib
@@ -884,12 +866,6 @@ ifeq "$(OPENACC)" "true"
 	OPENACC_MESSAGE="MPAS was built with OpenACC accelerator support enabled."
 else
 	OPENACC_MESSAGE="MPAS was built without OpenACC accelerator support."
-endif
-
-ifeq "$(USE_CUBLAS)" "true"
-	CUBLAS_MESSAGE="MPAS was built with cuBLAS support enabled."
-else
-	CUBLAS_MESSAGE="MPAS was built without cuBLAS support."
 endif
 
 ifneq ($(wildcard .mpas_core_*), ) # CHECK FOR BUILT CORE
@@ -1120,7 +1096,6 @@ endif
 	@echo $(OPENMP_MESSAGE)
 	@echo $(OPENMP_OFFLOAD_MESSAGE)
 	@echo $(OPENACC_MESSAGE)
-	@echo $(CUBLAS_MESSAGE)
 	@echo $(SHAREDLIB_MESSAGE)
 ifeq "$(AUTOCLEAN)" "true"
 	@echo $(AUTOCLEAN_MESSAGE)
@@ -1200,9 +1175,8 @@ errmsg:
 	@echo "    PRECISION=single - builds with default single-precision real kind. Default is to use double-precision."
 	@echo "    SHAREDLIB=true - generate position-independent code suitable for use in a shared library. Default is false."
 	@echo "    USE_LAPACK=true - builds and links with LAPACK / BLAS libraries.  Default is to not use LAPACK."
-	@echo "    USE_CUBLAS=true - builds and links with cuBLAS libraries.  Default is to not use cuBLAS."
 	@echo ""
-	@echo "Ensure that NETCDF, PNETCDF, PIO, LAPACK (if USE_LAPACK=true), cuBLAS (if USE_CUBLAS=true) and PAPI (if USE_PAPI=true) are environment variables"
+	@echo "Ensure that NETCDF, PNETCDF, PIO, LAPACK (if USE_LAPACK=true) and PAPI (if USE_PAPI=true) are environment variables"
 	@echo "that point to the absolute paths for the libraries."
 	@echo ""
 ifdef CORE

--- a/src/framework-sed/mpas_dmpar.F
+++ b/src/framework-sed/mpas_dmpar.F
@@ -91,6 +91,7 @@ include 'mpif.h'
    public :: mpas_dmpar_min_int_array
    public :: mpas_dmpar_max_int_array
    public :: mpas_dmpar_sum_real_array
+   public :: mpas_dmpar_sum_real_array_gpu
    public :: mpas_dmpar_min_real_array
    public :: mpas_dmpar_max_real_array
    public :: mpas_dmpar_scatter_ints
@@ -1294,6 +1295,38 @@ include 'mpif.h'
       end if
 
    end subroutine mpas_dmpar_sum_real_array!}}}
+
+   subroutine mpas_dmpar_sum_real_array_gpu(dminfo, nElements, inArray, outArray)!{{{
+
+      implicit none
+
+      type (dm_info), intent(in) :: dminfo !< Input: Domain information
+      integer, intent(in) :: nElements !< Input: Length of arrays
+      real(kind=RKIND), dimension(nElements), intent(in) :: inArray !< Input: Array of reals
+      real(kind=RKIND), dimension(nElements), intent(out) :: outArray !< Output: Array of real sums
+
+      integer :: mpi_ierr, threadNum, k
+
+      threadNum = mpas_threading_get_thread_num()
+
+      if ( threadNum == 0 ) then
+!$acc data present(outArray,inArray)
+#ifdef _MPI
+!$acc host_data use_device(inArray,outArray)
+         call MPI_Allreduce(inArray, outArray, nElements, MPI_REALKIND, MPI_SUM, dminfo % comm, mpi_ierr)
+!$acc end host_data
+#else
+!$acc parallel
+!$acc loop gang vector     
+         do k = 1, nElements
+            outArray(k) = inArray(k)
+         enddo
+!$acc end parallel
+#endif
+!$acc end data
+      end if
+
+   end subroutine mpas_dmpar_sum_real_array_gpu!}}}
 
 !-----------------------------------------------------------------------
 !  routine mpas_dmpar_min_real_array
@@ -8483,6 +8516,8 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
           exchListPtr => fieldCursor % sendList % halos(haloLayer) % exchList
           do while ( associated(exchListPtr) )
             if ( exchListPtr % endPointID == commListPtr % procID ) then
+!$acc enter data copyin(fieldCursor % array)
+!$acc update host(fieldCursor % array)
               do iExch = 1, exchListPtr % nList
                  iBuffer = exchListPtr % destList(iExch) + bufferOffset
                  commListPtr % rbuffer(iBuffer) = transfer(fieldCursor % array(exchListPtr % srcList(iExch)), commListPtr % rbuffer(1))
@@ -8552,6 +8587,8 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
           exchListPtr => fieldCursor % sendList % halos(haloLayer) % exchList
           do while ( associated(exchListPtr) )
             if ( exchListPtr % endPointID == commListPtr % procID ) then
+!$acc enter data copyin(fieldCursor % array)
+!$acc update host(fieldCursor % array)
               do iExch = 1, exchListPtr % nList
                 do j = 1, fieldCursor % dimSizes(1)
                   iBuffer = (exchListPtr % destList(iExch)-1) * fieldCursor % dimSizes(1) + j + bufferOffset
@@ -8624,6 +8661,8 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
           exchListPtr => fieldCursor % sendList % halos(haloLayer) % exchList
           do while ( associated(exchListPtr) )
             if ( exchListPtr % endPointID == commListPtr % procID ) then
+!$acc enter data copyin(fieldCursor % array)
+!$acc update host(fieldCursor % array)
               do iExch = 1, exchListPtr % nList
                 do j = 1, fieldCursor % dimSizes(2)
                   do k = 1, fieldCursor % dimSizes(1)
@@ -8698,6 +8737,8 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
           exchListPtr => fieldCursor % sendList % halos(haloLayer) % exchList
           do while ( associated(exchListPtr) )
             if ( exchListPtr % endPointID == commListPtr % procID ) then
+!$acc enter data copyin(fieldCursor % array)
+!$acc update host(fieldCursor % array)
               do iExch = 1, exchListPtr % nList
                 iBuffer = exchListPtr % destList(iExch) + bufferOffset
                 commListPtr % rbuffer(iBuffer) = fieldCursor % array(exchListPtr % srcList(iExch))
@@ -8767,6 +8808,8 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
           exchListPtr => fieldCursor % sendList % halos(haloLayer) % exchList
           do while ( associated(exchListPtr) )
             if ( exchListPtr % endPointID == commListPtr % procID ) then
+!$acc enter data copyin(fieldCursor % array)
+!$acc update host(fieldCursor % array)
               do iExch = 1, exchListPtr % nList
                 do j = 1, fieldCursor % dimSizes(1)
                   iBuffer = (exchListPtr % destList(iExch)-1) * fieldCursor % dimSizes(1) + j + bufferOffset
@@ -8838,6 +8881,8 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
            exchListPtr => fieldCursor % sendList % halos(haloLayer) % exchList
            do while ( associated(exchListPtr) )
              if ( exchListPtr % endPointID == commListPtr % procID ) then
+!$acc enter data copyin(fieldCursor % array)
+!$acc update host(fieldCursor % array)
                do iExch = 1, exchListPtr % nList
                  do j = 1, fieldCursor % dimSizes(2)
                    do k = 1, fieldCursor % dimSizes(1)
@@ -8912,6 +8957,8 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
           exchListPtr => fieldCursor % sendList % halos(haloLayer) % exchList
           do while ( associated(exchListPtr) )
             if ( exchListPtr % endPointID == commListPtr % procID ) then
+!$acc enter data copyin(fieldCursor % array)
+!$acc update host(fieldCursor % array)
               do iExch = 1, exchListPtr % nList
                 do j = 1, fieldCursor % dimSizes(3)
                   do k = 1, fieldCursor % dimSizes(2)
@@ -8989,6 +9036,8 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
           exchListPtr => fieldCursor % sendList % halos(haloLayer) % exchList
           do while ( associated(exchListPtr) )
             if ( exchListPtr % endPointID == commListPtr % procID ) then
+!$acc enter data copyin(fieldCursor % array)
+!$acc update host(fieldCursor % array)
               do iExch = 1, exchListPtr % nList
                 do j = 1, fieldCursor % dimSizes(4)
                   do k = 1, fieldCursor % dimSizes(3)
@@ -9057,11 +9106,13 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             fieldCursor2 => field
             do while ( associated(fieldCursor2) )
                if ( exchListPtr % endPointID == fieldCursor2 % block % localBlockID ) then
+!$acc update host(fieldCursor2 % array, fieldCursor % array)
                   !$omp do schedule(runtime)
                   do iExch = 1, exchListPtr % nList
                      fieldCursor2 % array(exchListPtr % destList(iExch)) = fieldCursor % array(exchListPtr % srcList(iExch))
                   end do
                   !$omp end do
+!$acc update device(fieldCursor2 % array, fieldCursor % array)
                end if
 
                fieldCursor2 => fieldCursor2 % next
@@ -9112,11 +9163,13 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             fieldCursor2 => field
             do while ( associated(fieldCursor2) )
                if ( exchListPtr % endPointID == fieldCursor2 % block % localBlockID ) then
+!$acc update host(fieldCursor2 % array, fieldCursor % array)
                   !$omp do schedule(runtime)
                   do iExch = 1, exchListPtr % nList
                      fieldCursor2 % array(:, exchListPtr % destList(iExch)) = fieldCursor % array(:, exchListPtr % srcList(iExch))
                   end do
                   !$omp end do
+!$acc update device(fieldCursor2 % array, fieldCursor % array)
                end if
 
                fieldCursor2 => fieldCursor2 % next
@@ -9167,12 +9220,14 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             fieldCursor2 => field
             do while ( associated(fieldCursor2) )
                if ( exchListPtr % endPointID == fieldCursor2 % block % localBlockID ) then
+!$acc update host(fieldCursor2 % array, fieldCursor % array)
                   !$omp do schedule(runtime)
                   do iExch = 1, exchListPtr % nList
                      fieldCursor2 % array(:, :, exchListPtr % destList(iExch)) = &
                                   fieldCursor % array(:, :, exchListPtr % srcList(iExch))
                   end do
                   !$omp end do
+!$acc update device(fieldCursor2 % array, fieldCursor % array)
                end if
 
                fieldCursor2 => fieldCursor2 % next
@@ -9223,11 +9278,13 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             fieldCursor2 => field
             do while ( associated(fieldCursor2) )
                if ( exchListPtr % endPointID == fieldCursor2 % block % localBlockID ) then
+!$acc update host(fieldCursor2 % array, fieldCursor % array)
                   !$omp do schedule(runtime)
                   do iExch = 1, exchListPtr % nList
                      fieldCursor2 % array(exchListPtr % destList(iExch)) = fieldCursor % array(exchListPtr % srcList(iExch))
                   end do
                   !$omp end do
+!$acc update device(fieldCursor2 % array, fieldCursor % array)
                end if
 
                fieldCursor2 => fieldCursor2 % next
@@ -9278,11 +9335,13 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             fieldCursor2 => field
             do while ( associated(fieldCursor2) )
                if ( exchListPtr % endPointID == fieldCursor2 % block % localBlockID ) then
+!$acc update host(fieldCursor2 % array, fieldCursor % array)
                   !$omp do schedule(runtime)
                   do iExch = 1, exchListPtr % nList
                      fieldCursor2 % array(:, exchListPtr % destList(iExch)) = fieldCursor % array(:, exchListPtr % srcList(iExch))
                   end do
                   !$omp end do
+!$acc update device(fieldCursor2 % array, fieldCursor % array)
                end if
 
                fieldCursor2 => fieldCursor2 % next
@@ -9333,12 +9392,14 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             fieldCursor2 => field
             do while ( associated(fieldCursor2) )
                if(exchListPtr % endPointID == fieldCursor2 % block % localBlockID) then
+!$acc update host(fieldCursor2 % array, fieldCursor % array)
                   !$omp do schedule(runtime)
                   do iExch = 1, exchListPtr % nList
                      fieldCursor2 % array(:, :, exchListPtr % destList(iExch)) = &
                                   fieldCursor % array(:, :, exchListPtr % srcList(iExch))
                   end do
                   !$omp end do
+!$acc update device(fieldCursor2 % array, fieldCursor % array)
                end if
 
                fieldCursor2 => fieldCursor2 % next
@@ -9389,12 +9450,14 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             fieldCursor2 => field
             do while ( associated(fieldCursor2) )
                if ( exchListPtr % endPointID == fieldCursor2 % block % localBlockID ) then
+!$acc update host(fieldCursor2 % array, fieldCursor % array)
                   !$omp do schedule(runtime)
                   do iExch = 1, exchListPtr % nList
                      fieldCursor2 % array(:, :, :, exchListPtr % destList(iExch)) = &
                                   fieldCursor % array(:, :, :, exchListPtr % srcList(iExch))
                   end do
                   !$omp end do
+!$acc update device(fieldCursor2 % array, fieldCursor % array)
                end if
 
                fieldCursor2 => fieldCursor2 % next
@@ -9445,12 +9508,14 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
             fieldCursor2 => field
             do while ( associated(fieldCursor2) )
                if ( exchListPtr % endPointID == fieldCursor2 % block % localBlockID ) then
+!$acc update host(fieldCursor2 % array, fieldCursor % array)
                   !$omp do schedule(runtime)
                   do iExch = 1, exchListPtr % nList
                      fieldCursor2 % array(:, :, :, :, exchListPtr % destList(iExch)) = &
                                   fieldCursor % array(:, :, :, :, exchListPtr % srcList(iExch))
                   end do
                   !$omp end do
+!$acc update device(fieldCursor2 % array, fieldCursor % array)
                end if
 
                fieldCursor2 => fieldCursor2 % next
@@ -9519,6 +9584,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
                                                                                 fieldCursor % array(1))
                end do
                !$omp end do
+!$acc update device(fieldCursor % array)
                nAdded = max(nAdded, maxval(exchListPtr % srcList))
             end if
             exchListPtr => exchListPtr % next
@@ -9584,6 +9650,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
                   end do
                end do
                !$omp end do
+!$acc update device(fieldCursor % array)
                nAdded = max(nAdded, maxval(exchListPtr % srcList) * fieldCursor % dimSizes(1))
             end if
             exchListPtr => exchListPtr % next
@@ -9652,6 +9719,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
                   end do
                end do
                !$omp end do
+!$acc update device(fieldCursor % array)
                nAdded = max(nAdded, maxval(exchListPtr % srcList) * fieldCursor % dimSizes(1) * fieldCursor % dimSizes(2))
             end if
             exchListPtr => exchListPtr % next
@@ -9713,6 +9781,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
                   fieldCursor % array(exchListPtr % destList(iExch)) = recvList % rbuffer(iBuffer)
                end do
                !$omp end do
+!$acc update device(fieldCursor % array)
                nAdded = max(nAdded, maxval(exchListPtr % srcList))
             end if
             exchListPtr => exchListPtr % next
@@ -9777,6 +9846,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
                   end do
                end do
                !$omp end do
+!$acc update device(fieldCursor % array)
                nAdded = max(nAdded, maxval(exchListPtr % srcList) * fieldCursor % dimSizes(1))
             end if
             exchListPtr => exchListPtr % next
@@ -9844,6 +9914,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
                   end do
                end do
                !$omp end do
+!$acc update device(fieldCursor % array)
                nAdded = max(nAdded, maxval(exchListPtr % srcList) * fieldCursor % dimSizes(1) * fieldCursor % dimSizes(2))
             end if
             exchListPtr => exchListPtr % next
@@ -9915,6 +9986,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
                   end do
                end do
                !$omp end do
+!$acc update device(fieldCursor % array)
                nAdded = max(nAdded, maxval(exchListPtr % srcList) * fieldCursor % dimSizes(1) &
                       * fieldCursor % dimSizes(2) * fieldCursor % dimSizes(3))
             end if
@@ -9991,6 +10063,7 @@ subroutine mpas_dmpar_get_exch_list(haloLayer, ownedListField, neededListField, 
                   end do
                end do
                !$omp end do
+!$acc update device(fieldCursor % array)
                nAdded = max(nAdded, maxval(exchListPtr % srcList) * fieldCursor % dimSizes(1) * fieldCursor % dimSizes(2) &
                       * fieldCursor % dimSizes(3) * fieldCursor % dimSizes(4))
             end if

--- a/src/framework-sed/mpas_pool_routines.F
+++ b/src/framework-sed/mpas_pool_routines.F
@@ -81,6 +81,21 @@ module MPASAOS_pool_routines
       module procedure mpas_pool_get_array_1d_char
    end interface
 
+   interface mpas_pool_get_array_gpu
+      module procedure mpas_pool_get_array_0d_real_gpu
+      module procedure mpas_pool_get_array_1d_real_gpu
+      module procedure mpas_pool_get_array_2d_real_gpu
+      module procedure mpas_pool_get_array_3d_real_gpu
+      module procedure mpas_pool_get_array_4d_real_gpu
+      module procedure mpas_pool_get_array_5d_real_gpu
+      module procedure mpas_pool_get_array_0d_int_gpu
+      module procedure mpas_pool_get_array_1d_int_gpu
+      module procedure mpas_pool_get_array_2d_int_gpu
+      module procedure mpas_pool_get_array_3d_int_gpu
+      module procedure mpas_pool_get_array_0d_char_gpu
+      module procedure mpas_pool_get_array_1d_char_gpu
+   end interface
+
    interface mpas_pool_add_config
       module procedure mpas_pool_add_config_real
       module procedure mpas_pool_add_config_int
@@ -4203,6 +4218,27 @@ module MPASAOS_pool_routines
 
    end subroutine mpas_pool_get_array_0d_real!}}}
 
+   subroutine mpas_pool_get_array_0d_real_gpu(inPool, key, scalar, timeLevel)!{{{
+
+      implicit none
+
+      type (mpas_pool_type), intent(in) :: inPool
+      character (len=*), intent(in) :: key
+      real (kind=RKIND), pointer :: scalar
+      integer, intent(in), optional :: timeLevel
+
+      type (field0DReal), pointer :: field
+
+
+      call mpas_pool_get_field_0d_real(inPool, key, field, timeLevel)
+
+      nullify(scalar)
+      if (associated(field)) then
+         scalar => field % scalar
+         !$acc enter data copyin(field % scalar)
+      endif
+
+   end subroutine mpas_pool_get_array_0d_real_gpu!}}}
 
 !-----------------------------------------------------------------------
 !  subroutine mpas_pool_get_array_1d_real
@@ -4233,6 +4269,27 @@ module MPASAOS_pool_routines
 
    end subroutine mpas_pool_get_array_1d_real!}}}
 
+   subroutine mpas_pool_get_array_1d_real_gpu(inPool, key, array, timeLevel)!{{{
+
+      implicit none
+
+      type (mpas_pool_type), intent(in) :: inPool
+      character (len=*), intent(in) :: key
+      real (kind=RKIND), dimension(:), pointer :: array
+      integer, intent(in), optional :: timeLevel
+
+      type (field1DReal), pointer :: field
+
+
+      call mpas_pool_get_field_1d_real(inPool, key, field, timeLevel)
+
+      nullify(array)
+      if (associated(field)) then
+         array => field % array
+         !$acc enter data copyin(field % array)
+      endif
+
+   end subroutine mpas_pool_get_array_1d_real_gpu!}}}
 
 !-----------------------------------------------------------------------
 !  subroutine mpas_pool_get_array_2d_real
@@ -4263,6 +4320,27 @@ module MPASAOS_pool_routines
 
    end subroutine mpas_pool_get_array_2d_real!}}}
 
+   subroutine mpas_pool_get_array_2d_real_gpu(inPool, key, array, timeLevel)!{{{
+
+      implicit none
+
+      type (mpas_pool_type), intent(in) :: inPool
+      character (len=*), intent(in) :: key
+      real (kind=RKIND), dimension(:,:), pointer :: array
+      integer, intent(in), optional :: timeLevel
+
+      type (field2DReal), pointer :: field
+
+
+      call mpas_pool_get_field_2d_real(inPool, key, field, timeLevel)
+
+      nullify(array)
+      if (associated(field)) then
+         array => field % array
+         !$acc enter data copyin(field % array)
+      endif
+
+   end subroutine mpas_pool_get_array_2d_real_gpu!}}}
 
 !-----------------------------------------------------------------------
 !  subroutine mpas_pool_get_array_3d_real
@@ -4293,6 +4371,27 @@ module MPASAOS_pool_routines
 
    end subroutine mpas_pool_get_array_3d_real!}}}
 
+   subroutine mpas_pool_get_array_3d_real_gpu(inPool, key, array, timeLevel)!{{{
+
+      implicit none
+
+      type (mpas_pool_type), intent(in) :: inPool
+      character (len=*), intent(in) :: key
+      real (kind=RKIND), dimension(:,:,:), pointer :: array
+      integer, intent(in), optional :: timeLevel
+
+      type (field3DReal), pointer :: field
+
+
+      call mpas_pool_get_field_3d_real(inPool, key, field, timeLevel)
+
+      nullify(array)
+      if (associated(field)) then
+         array => field % array
+         !$acc enter data copyin(field % array)
+      endif
+
+   end subroutine mpas_pool_get_array_3d_real_gpu!}}}
 
 !-----------------------------------------------------------------------
 !  subroutine mpas_pool_get_array_4d_real
@@ -4323,6 +4422,27 @@ module MPASAOS_pool_routines
 
    end subroutine mpas_pool_get_array_4d_real!}}}
 
+   subroutine mpas_pool_get_array_4d_real_gpu(inPool, key, array, timeLevel)!{{{
+
+      implicit none
+
+      type (mpas_pool_type), intent(in) :: inPool
+      character (len=*), intent(in) :: key
+      real (kind=RKIND), dimension(:,:,:,:), pointer :: array
+      integer, intent(in), optional :: timeLevel
+
+      type (field4DReal), pointer :: field
+
+
+      call mpas_pool_get_field_4d_real(inPool, key, field, timeLevel)
+
+      nullify(array)
+      if (associated(field)) then
+         array => field % array
+         !$acc enter data copyin(field % array)
+      endif
+
+   end subroutine mpas_pool_get_array_4d_real_gpu!}}}
 
 !-----------------------------------------------------------------------
 !  subroutine mpas_pool_get_array_5d_real
@@ -4353,6 +4473,27 @@ module MPASAOS_pool_routines
 
    end subroutine mpas_pool_get_array_5d_real!}}}
 
+   subroutine mpas_pool_get_array_5d_real_gpu(inPool, key, array, timeLevel)!{{{
+
+      implicit none
+
+      type (mpas_pool_type), intent(in) :: inPool
+      character (len=*), intent(in) :: key
+      real (kind=RKIND), dimension(:,:,:,:,:), pointer :: array
+      integer, intent(in), optional :: timeLevel
+
+      type (field5DReal), pointer :: field
+
+
+      call mpas_pool_get_field_5d_real(inPool, key, field, timeLevel)
+
+      nullify(array)
+      if (associated(field)) then
+         array => field % array
+         !$acc enter data copyin(field % array)
+      endif
+
+   end subroutine mpas_pool_get_array_5d_real_gpu!}}}
 
 !-----------------------------------------------------------------------
 !  subroutine mpas_pool_get_array_0d_int
@@ -4383,6 +4524,27 @@ module MPASAOS_pool_routines
 
    end subroutine mpas_pool_get_array_0d_int!}}}
 
+   subroutine mpas_pool_get_array_0d_int_gpu(inPool, key, scalar, timeLevel)!{{{
+
+      implicit none
+
+      type (mpas_pool_type), intent(in) :: inPool
+      character (len=*), intent(in) :: key
+      integer, pointer :: scalar
+      integer, intent(in), optional :: timeLevel
+
+      type (field0DInteger), pointer :: field
+
+
+      call mpas_pool_get_field_0d_int(inPool, key, field, timeLevel)
+
+      nullify(scalar)
+      if (associated(field)) then
+         scalar => field % scalar
+         !$acc enter data copyin(field % scalar)
+      endif
+
+   end subroutine mpas_pool_get_array_0d_int_gpu!}}}
 
 !-----------------------------------------------------------------------
 !  subroutine mpas_pool_get_array_1d_int
@@ -4413,6 +4575,27 @@ module MPASAOS_pool_routines
 
    end subroutine mpas_pool_get_array_1d_int!}}}
 
+   subroutine mpas_pool_get_array_1d_int_gpu(inPool, key, array, timeLevel)!{{{
+
+      implicit none
+
+      type (mpas_pool_type), intent(in) :: inPool
+      character (len=*), intent(in) :: key
+      integer, dimension(:), pointer :: array
+      integer, intent(in), optional :: timeLevel
+
+      type (field1DInteger), pointer :: field
+
+
+      call mpas_pool_get_field_1d_int(inPool, key, field, timeLevel)
+
+      nullify(array)
+      if (associated(field)) then
+         array => field % array
+         !$acc enter data copyin(field % array)
+      endif
+
+   end subroutine mpas_pool_get_array_1d_int_gpu!}}}
 
 !-----------------------------------------------------------------------
 !  subroutine mpas_pool_get_array_2d_int
@@ -4443,6 +4626,27 @@ module MPASAOS_pool_routines
 
    end subroutine mpas_pool_get_array_2d_int!}}}
 
+   subroutine mpas_pool_get_array_2d_int_gpu(inPool, key, array, timeLevel)!{{{
+
+      implicit none
+
+      type (mpas_pool_type), intent(in) :: inPool
+      character (len=*), intent(in) :: key
+      integer, dimension(:,:), pointer :: array
+      integer, intent(in), optional :: timeLevel
+
+      type (field2DInteger), pointer :: field
+
+
+      call mpas_pool_get_field_2d_int(inPool, key, field, timeLevel)
+
+      nullify(array)
+      if (associated(field)) then
+         array => field % array
+         !$acc enter data copyin(field % array)
+      endif
+
+   end subroutine mpas_pool_get_array_2d_int_gpu!}}}
 
 !-----------------------------------------------------------------------
 !  subroutine mpas_pool_get_array_3d_int
@@ -4473,6 +4677,27 @@ module MPASAOS_pool_routines
 
    end subroutine mpas_pool_get_array_3d_int!}}}
 
+   subroutine mpas_pool_get_array_3d_int_gpu(inPool, key, array, timeLevel)!{{{
+
+      implicit none
+
+      type (mpas_pool_type), intent(in) :: inPool
+      character (len=*), intent(in) :: key
+      integer, dimension(:,:,:), pointer :: array
+      integer, intent(in), optional :: timeLevel
+
+      type (field3DInteger), pointer :: field
+
+
+      call mpas_pool_get_field_3d_int(inPool, key, field, timeLevel)
+
+      nullify(array)
+      if (associated(field)) then
+         array => field % array
+         !$acc enter data copyin(field % array)
+      endif
+
+   end subroutine mpas_pool_get_array_3d_int_gpu!}}}
 
 !-----------------------------------------------------------------------
 !  subroutine mpas_pool_get_array_0d_char
@@ -4503,6 +4728,27 @@ module MPASAOS_pool_routines
 
    end subroutine mpas_pool_get_array_0d_char!}}}
 
+   subroutine mpas_pool_get_array_0d_char_gpu(inPool, key, string, timeLevel)!{{{
+
+      implicit none
+
+      type (mpas_pool_type), intent(in) :: inPool
+      character (len=*), intent(in) :: key
+      character (len=StrKIND), pointer :: string
+      integer, intent(in), optional :: timeLevel
+
+      type (field0DChar), pointer :: field
+
+
+      call mpas_pool_get_field_0d_char(inPool, key, field, timeLevel)
+
+      nullify(string)
+      if (associated(field)) then
+         string => field % scalar
+         !$acc enter data copyin(field % scalar)
+      endif
+
+   end subroutine mpas_pool_get_array_0d_char_gpu!}}}
 
 !-----------------------------------------------------------------------
 !  subroutine mpas_pool_get_array_1d_char
@@ -4533,6 +4779,27 @@ module MPASAOS_pool_routines
 
    end subroutine mpas_pool_get_array_1d_char!}}}
 
+   subroutine mpas_pool_get_array_1d_char_gpu(inPool, key, array, timeLevel)!{{{
+
+      implicit none
+
+      type (mpas_pool_type), intent(in) :: inPool
+      character (len=*), intent(in) :: key
+      character (len=StrKIND), dimension(:), pointer :: array
+      integer, intent(in), optional :: timeLevel
+
+      type (field1DChar), pointer :: field
+
+
+      call mpas_pool_get_field_1d_char(inPool, key, field, timeLevel)
+
+      nullify(array)
+      if (associated(field)) then
+         array => field % array
+         !$acc enter data copyin(field % array)
+      endif
+
+   end subroutine mpas_pool_get_array_1d_char_gpu!}}}
 
 !-----------------------------------------------------------------------
 !  routine mpas_pool_add_config_real


### PR DESCRIPTION
This PR includes the below changes:
- Port of 'mpas_pool_get_array' routine to create and transfer variables to GPUs.
- Port of 'mpas_dmpar_sum_real_array' routine to use device pointers for MPI_Allreduce call.
- Added data transfer in the halo exchange routines to update the variables on host for MPI communications.
- Includes updates to Makefile: Added NVTX flags, updated OpenACC flags, added cuBLAS related flags, and updated optimization flags.



